### PR TITLE
Replace jQuery with vanilla JavaScript

### DIFF
--- a/assets/js/quick-edit-series-parts.js
+++ b/assets/js/quick-edit-series-parts.js
@@ -6,11 +6,13 @@
  *
  * Global dependency: contentSeriesQuickEditData (provided via wp_add_inline_script)
  */
+
+/* global MutationObserver */
+
 ( function () {
 	// Timeout constants (in milliseconds).
 	const DOM_UPDATE_DELAY = 200; // Wait for WordPress to update DOM after save
-	const AJAX_CLEANUP_TIMEOUT = 10000; // Force remove AJAX handler after 10 seconds
-	const FALLBACK_SAVE_DELAY = 1000; // Assume save completed if jQuery unavailable
+	const OBSERVER_CLEANUP_TIMEOUT = 10000; // Force disconnect observer after 10 seconds
 
 	// Get REST URL from inline script data (global provided by WordPress).
 	const restUrl = contentSeriesQuickEditData.restUrl;
@@ -574,28 +576,26 @@
 		// Call original save function.
 		wpInlineSave.apply( this, arguments );
 
-		// Listen for AJAX completion to update counts after save.
-		let cleanupTimeoutId;
-		const ajaxCompleteHandler = function ( event, xhr, settings ) {
-			// Check if this is the inline-save AJAX request.
-			if (
-				settings.data &&
-				settings.data.indexOf( 'action=inline-save' ) !== -1
-			) {
-				// Remove handler to prevent multiple triggers.
-				if ( typeof jQuery !== 'undefined' ) {
-					jQuery( document ).off(
-						'ajaxComplete',
-						ajaxCompleteHandler
-					);
-				}
+		// Use MutationObserver to detect when WordPress removes the edit row after save.
+		// WordPress replaces #edit-{id} with the updated post row on successful save.
+		const editRow = document.getElementById( 'edit-' + post_id );
+		if ( ! editRow || ! editRow.parentNode ) {
+			// Edit row not found, can't observe - clean up and exit.
+			delete seriesBeforeSave[ post_id ];
+			return;
+		}
 
-				// Clear the cleanup timeout since handler fired successfully.
-				if ( cleanupTimeoutId ) {
-					clearTimeout( cleanupTimeoutId );
-				}
+		// Track cleanup state to coordinate between observer and timeout.
+		let observerFired = false;
 
-				// Wait for DOM to update (WordPress updates the row asynchronously).
+		const observer = new MutationObserver( function () {
+			// Check if the edit row was removed from DOM.
+			if ( ! document.getElementById( 'edit-' + post_id ) ) {
+				// Edit row removed - save completed successfully.
+				observerFired = true;
+				observer.disconnect();
+
+				// Wait for DOM to fully stabilize (WordPress uses fadeIn animation).
 				setTimeout( function () {
 					if ( post_id > 0 ) {
 						updateSeriesCountsAfterSave(
@@ -607,33 +607,21 @@
 					}
 				}, DOM_UPDATE_DELAY );
 			}
-		};
+		} );
 
-		// Attach handler (using jQuery since WordPress uses it for AJAX).
-		// If jQuery is not available, we'll assume success after a delay.
-		if ( typeof jQuery !== 'undefined' ) {
-			jQuery( document ).on( 'ajaxComplete', ajaxCompleteHandler );
+		// Observe the parent element for child list changes.
+		observer.observe( editRow.parentNode, { childList: true } );
 
-			// Add timeout to forcibly remove handler if AJAX never completes (prevents memory leak).
-			cleanupTimeoutId = setTimeout( function () {
-				jQuery( document ).off( 'ajaxComplete', ajaxCompleteHandler );
+		// Add timeout to forcibly disconnect observer if save never completes (prevents memory leak).
+		setTimeout( function () {
+			if ( ! observerFired ) {
+				observer.disconnect();
 				// Clean up tracking data.
 				if ( post_id > 0 && seriesBeforeSave[ post_id ] ) {
 					delete seriesBeforeSave[ post_id ];
 				}
-			}, AJAX_CLEANUP_TIMEOUT );
-		} else {
-			// Fallback: assume save completed successfully after a delay.
-			setTimeout( function () {
-				if ( post_id > 0 ) {
-					updateSeriesCountsAfterSave(
-						post_id,
-						seriesBeforeSave[ post_id ] || []
-					);
-					delete seriesBeforeSave[ post_id ];
-				}
-			}, FALLBACK_SAVE_DELAY );
-		}
+			}
+		}, OBSERVER_CLEANUP_TIMEOUT );
 	};
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -275,7 +275,7 @@ class Admin {
 		wp_enqueue_script(
 			'content-series-quick-edit',
 			CONTENT_SERIES_URL . 'assets/js/quick-edit-series-parts.js',
-			array( 'jquery' ),
+			array( 'inline-edit-post' ),
 			CONTENT_SERIES_VERSION,
 			true
 		);

--- a/includes/class-term-meta.php
+++ b/includes/class-term-meta.php
@@ -235,40 +235,58 @@ class Term_Meta {
 	 */
 	private function get_media_script() {
 		return "
-		jQuery(document).ready(function($) {
+		document.addEventListener('DOMContentLoaded', function() {
 			var mediaFrame;
 
-			$('.series-icon-upload').on('click', function(e) {
-				e.preventDefault();
+			document.querySelectorAll('.series-icon-upload').forEach(function(btn) {
+				btn.addEventListener('click', function(e) {
+					e.preventDefault();
 
-				if (mediaFrame) {
+					if (mediaFrame) {
+						mediaFrame.open();
+						return;
+					}
+
+					mediaFrame = wp.media({
+						title: '" . esc_js( __( 'Select Series Icon', 'content-series' ) ) . "',
+						button: { text: '" . esc_js( __( 'Use as Icon', 'content-series' ) ) . "' },
+						multiple: false
+					});
+
+					mediaFrame.on('select', function() {
+						var attachment = mediaFrame.state().get('selection').first().toJSON();
+						document.getElementById('series_icon').value = attachment.url;
+						document.getElementById('series_icon_id').value = attachment.id;
+						var preview = document.querySelector('.series-icon-preview');
+						if (preview) {
+							preview.textContent = '';
+							var img = document.createElement('img');
+							img.src = attachment.url;
+							img.style.maxWidth = '150px';
+							img.style.maxHeight = '150px';
+							preview.appendChild(img);
+						}
+						var removeBtn = document.querySelector('.series-icon-remove');
+						if (removeBtn) {
+							removeBtn.style.display = '';
+						}
+					});
+
 					mediaFrame.open();
-					return;
-				}
-
-				mediaFrame = wp.media({
-					title: '" . esc_js( __( 'Select Series Icon', 'content-series' ) ) . "',
-					button: { text: '" . esc_js( __( 'Use as Icon', 'content-series' ) ) . "' },
-					multiple: false
 				});
-
-				mediaFrame.on('select', function() {
-					var attachment = mediaFrame.state().get('selection').first().toJSON();
-					$('#series_icon').val(attachment.url);
-					$('#series_icon_id').val(attachment.id);
-					$('.series-icon-preview').html('<img src=\"' + attachment.url + '\" style=\"max-width: 150px; max-height: 150px;\">');
-					$('.series-icon-remove').show();
-				});
-
-				mediaFrame.open();
 			});
 
-			$('.series-icon-remove').on('click', function(e) {
-				e.preventDefault();
-				$('#series_icon').val('');
-				$('#series_icon_id').val('');
-				$('.series-icon-preview').html('');
-				$(this).hide();
+			document.querySelectorAll('.series-icon-remove').forEach(function(btn) {
+				btn.addEventListener('click', function(e) {
+					e.preventDefault();
+					document.getElementById('series_icon').value = '';
+					document.getElementById('series_icon_id').value = '';
+					var preview = document.querySelector('.series-icon-preview');
+					if (preview) {
+						preview.innerHTML = '';
+					}
+					this.style.display = 'none';
+				});
 			});
 		});
 		";


### PR DESCRIPTION
## Summary

- Replace jQuery `ajaxComplete` with `MutationObserver` in quick-edit-series-parts.js to detect save completion
- Convert term-meta.php media uploader inline script from jQuery to vanilla JS
- Change script dependency from `jquery` to `inline-edit-post`

## Changes

**quick-edit-series-parts.js**
- Use `MutationObserver` to watch for edit row removal instead of jQuery's `ajaxComplete` event
- WordPress removes `#edit-{postId}` when save completes, triggering the observer
- Includes cleanup timeout to prevent memory leaks if save never completes

**class-term-meta.php**
- `DOMContentLoaded` instead of `jQuery(document).ready()`
- `querySelectorAll().forEach()` with `addEventListener` instead of `$().on()`
- `document.getElementById().value` instead of `$().val()`
- `querySelector().innerHTML` instead of `$().html()`
- `style.display` instead of `show()/hide()`

**class-admin.php**
- Changed dependency from `jquery` to `inline-edit-post`

## Test plan

- [x] Quick Edit: Open quick edit, change series part number, save - verify save completes and values persist
- [x] Media Uploader: Go to Series taxonomy, click Select Image, choose image - verify preview displays and Remove button appears

Fixes #16