### PR TITLE
Remove dead series catalog shortcode code

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -16,8 +16,6 @@ class Admin {
 	 * Initialize admin hooks.
 	 */
 	public function init() {
-		add_shortcode( 'content_series_catalog', array( $this, 'render_catalog_shortcode' ) );
-
 		// Quick Edit functionality for series parts.
 		add_action( 'quick_edit_custom_box', array( $this, 'add_quick_edit_fields' ), 10, 2 );
 		add_action( 'save_post', array( $this, 'save_quick_edit_series_parts' ) );
@@ -38,83 +36,6 @@ class Admin {
 
 		wp_safe_redirect( admin_url( 'edit-tags.php?taxonomy=series' ) );
 		exit;
-	}
-
-	/**
-	 * Render the series catalog shortcode.
-	 *
-	 * @param array $atts Shortcode attributes.
-	 * @return string HTML output.
-	 */
-	public function render_catalog_shortcode( $atts ) {
-		$atts = shortcode_atts(
-			array(
-				'columns'    => 3,
-				'show_count' => true,
-				'show_icon'  => true,
-			),
-			$atts,
-			'content_series_catalog'
-		);
-
-		$terms = get_terms(
-			array(
-				'taxonomy'   => CONTENT_SERIES_TAXONOMY,
-				'hide_empty' => false,
-				'orderby'    => 'name',
-				'order'      => 'ASC',
-			)
-		);
-
-		if ( empty( $terms ) || is_wp_error( $terms ) ) {
-			return '<p>' . esc_html__( 'No series found.', 'content-series' ) . '</p>';
-		}
-
-		$columns = absint( $atts['columns'] );
-		$output  = '<div class="content-series-catalog" style="display: grid; grid-template-columns: repeat(' . $columns . ', 1fr); gap: 2rem;">';
-
-		foreach ( $terms as $term ) {
-			$icon_url = Term_Meta::get_series_icon( $term->term_id );
-			$link     = get_term_link( $term );
-
-			$output .= '<div class="content-series-catalog__item" style="text-align: center;">';
-
-			if ( $atts['show_icon'] && $icon_url ) {
-				$output .= sprintf(
-					'<a href="%s"><img src="%s" alt="%s" style="max-width: 150px; max-height: 150px; margin-bottom: 1rem;"></a>',
-					esc_url( $link ),
-					esc_url( $icon_url ),
-					esc_attr( $term->name )
-				);
-			}
-
-			$output .= sprintf(
-				'<h3 style="margin: 0 0 0.5rem;"><a href="%s">%s</a></h3>',
-				esc_url( $link ),
-				esc_html( $term->name )
-			);
-
-			if ( $atts['show_count'] ) {
-				$output .= sprintf(
-					'<p style="margin: 0; color: #666;">%s</p>',
-					/* translators: %d: number of posts */
-					esc_html( sprintf( _n( '%d post', '%d posts', $term->count, 'content-series' ), $term->count ) )
-				);
-			}
-
-			if ( $term->description ) {
-				$output .= sprintf(
-					'<p style="margin: 0.5rem 0 0; font-size: 0.9em;">%s</p>',
-					esc_html( wp_trim_words( $term->description, 20 ) )
-				);
-			}
-
-			$output .= '</div>';
-		}
-
-		$output .= '</div>';
-
-		return $output;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Removes the `content_series_catalog` shortcode registration from `init()`
- Removes the `render_catalog_shortcode()` method (76 lines of dead code)

This shortcode was superseded by the block-based catalog in PR #9. The code had no internal dependencies, no documentation, and no test coverage.

Closes #13

## Test plan
- [ ] Run `pnpm lint:php` - passes (no new errors)
- [ ] Verify `/series` catalog page still works (uses block template, not shortcode)