### PR TITLE
Fix series part suggestion initialization and typecheck

### DIFF
--- a/src/sidebar/series-extension-fields.tsx
+++ b/src/sidebar/series-extension-fields.tsx
@@ -10,9 +10,10 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { TextControl, Spinner } from '@wordpress/components';
-import { useMemo, useEffect } from '@wordpress/element';
+import { useMemo, useEffect, useCallback, useRef } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
 
-import type { SeriesOrder, WPTerm } from '../types';
+import type { SeriesData, SeriesOrder, WPTerm } from '../types';
 
 const TAXONOMY = 'series';
 
@@ -23,10 +24,13 @@ const EMPTY_ORDER: SeriesOrder = {};
 
 interface EditorSelectReturn {
 	currentSeriesIds: number[];
+	hasResolvedSeriesIds: boolean;
 	shortTitle: string;
 	seriesOrder: SeriesOrder;
 	isSaving: boolean;
 	postType: string;
+	postStatus?: string;
+	isNewPost: boolean;
 	canAssignTerms: boolean;
 }
 
@@ -39,20 +43,26 @@ export default function SeriesExtensionFields(): JSX.Element | null {
 	const { editPost } = useDispatch( editorStore ) as {
 		editPost: ( edits: Record< string, unknown > ) => void;
 	};
+	const hasInitializedSeriesRef = useRef( false );
+	const previousSeriesIdsRef = useRef< number[] >( [] );
 
 	// Get post data from editor store
 	const {
 		currentSeriesIds,
+		hasResolvedSeriesIds,
 		shortTitle,
 		seriesOrder,
 		isSaving,
 		postType,
+		postStatus,
+		isNewPost,
 		canAssignTerms,
 	} = useSelect( ( select ): EditorSelectReturn => {
 		const editorSelectors = select( editorStore ) as {
 			getEditedPostAttribute: ( attr: string ) => unknown;
 			isSavingPost: () => boolean;
 			getCurrentPostType: () => string;
+			isEditedPostNew?: () => boolean;
 			getCurrentPost: () => {
 				_links?: Record< string, unknown >;
 			};
@@ -77,6 +87,7 @@ export default function SeriesExtensionFields(): JSX.Element | null {
 
 		return {
 			currentSeriesIds: rawIds && rawIds.length > 0 ? rawIds : EMPTY_IDS,
+			hasResolvedSeriesIds: rawIds !== undefined,
 			shortTitle: ( meta?._spost_short_title as string ) || '',
 			seriesOrder:
 				rawOrder && Object.keys( rawOrder ).length > 0
@@ -84,6 +95,10 @@ export default function SeriesExtensionFields(): JSX.Element | null {
 					: EMPTY_ORDER,
 			isSaving: editorSelectors.isSavingPost(),
 			postType: editorSelectors.getCurrentPostType(),
+			postStatus: editorSelectors.getEditedPostAttribute( 'status' ) as
+				| string
+				| undefined,
+			isNewPost: editorSelectors.isEditedPostNew?.() ?? false,
 			canAssignTerms: hasAssignLink,
 		};
 	}, [] );
@@ -140,19 +155,120 @@ export default function SeriesExtensionFields(): JSX.Element | null {
 		[ currentSeriesQuery ]
 	);
 
-	// Initialize series_order for newly selected series that don't have an order yet
+	const shouldSuggestNextPart =
+		isNewPost || postStatus === 'draft' || postStatus === 'auto-draft';
+
+	const getSuggestedOrder = useCallback(
+		async ( seriesId: number ): Promise< number > => {
+			try {
+				const data = await apiFetch< SeriesData >( {
+					path: `/content-series/v1/series/${ seriesId }/posts`,
+				} );
+
+				if ( ! data.posts || data.posts.length === 0 ) {
+					return 1;
+				}
+
+				const highestPart = data.posts.reduce(
+					( highest, post ) =>
+						Math.max( highest, post.series_part || 1 ),
+					0
+				);
+
+				return highestPart + 1;
+			} catch {
+				return 1;
+			}
+		},
+		[]
+	);
+
+	// Initialize series_order when series terms are newly added to this post.
 	useEffect( () => {
-		const missingIds = currentSeriesIds.filter(
-			( id ) => ! ( id in seriesOrder )
-		);
-		if ( missingIds.length > 0 ) {
-			const newOrder = { ...seriesOrder };
-			missingIds.forEach( ( id ) => {
-				newOrder[ id ] = 1;
-			} );
-			editPost( { series_order: newOrder } );
+		if ( ! hasResolvedSeriesIds ) {
+			return;
 		}
-	}, [ currentSeriesIds, seriesOrder, editPost ] );
+
+		if ( ! hasInitializedSeriesRef.current ) {
+			previousSeriesIdsRef.current = currentSeriesIds;
+			hasInitializedSeriesRef.current = true;
+			return;
+		}
+
+		const previousSeriesIds = previousSeriesIdsRef.current;
+		if ( ! isNewPost && ! postStatus ) {
+			return;
+		}
+
+		const addedIds = currentSeriesIds.filter(
+			( id ) => ! previousSeriesIds.includes( id )
+		);
+		const removedIds = previousSeriesIds.filter(
+			( id ) => ! currentSeriesIds.includes( id )
+		);
+
+		if ( addedIds.length === 0 && removedIds.length === 0 ) {
+			return;
+		}
+
+		previousSeriesIdsRef.current = currentSeriesIds;
+		if ( addedIds.length === 0 ) {
+			return;
+		}
+
+		let isCancelled = false;
+
+		const initializeSeriesOrder = async (): Promise< void > => {
+			const newOrder = { ...seriesOrder };
+			let hasChanges = false;
+
+			if ( shouldSuggestNextPart ) {
+				const suggestions = await Promise.all(
+					addedIds.map( async ( id ) => ( {
+						id,
+						order: await getSuggestedOrder( id ),
+					} ) )
+				);
+
+				if ( isCancelled ) {
+					return;
+				}
+
+				suggestions.forEach( ( { id, order } ) => {
+					if ( newOrder[ id ] !== order ) {
+						newOrder[ id ] = order;
+						hasChanges = true;
+					}
+				} );
+			} else {
+				addedIds.forEach( ( id ) => {
+					if ( ! ( id in newOrder ) ) {
+						newOrder[ id ] = 1;
+						hasChanges = true;
+					}
+				} );
+			}
+
+			if ( hasChanges ) {
+				editPost( { series_order: newOrder } );
+			}
+		};
+
+		initializeSeriesOrder();
+
+		return () => {
+			isCancelled = true;
+		};
+	}, [
+		currentSeriesIds,
+		editPost,
+		getSuggestedOrder,
+		hasResolvedSeriesIds,
+		isNewPost,
+		postStatus,
+		seriesOrder,
+		shouldSuggestNextPart,
+	] );
 
 	// Handle order change for a specific series
 	const handleOrderChange = ( seriesId: number, newOrder: string ): void => {

--- a/src/sidebar/series-extension-fields.tsx
+++ b/src/sidebar/series-extension-fields.tsx
@@ -45,6 +45,7 @@ export default function SeriesExtensionFields(): JSX.Element | null {
 	};
 	const hasInitializedSeriesRef = useRef( false );
 	const previousSeriesIdsRef = useRef< number[] >( [] );
+	const pendingSeriesIdsRef = useRef< number[] >( [] );
 
 	// Get post data from editor store
 	const {
@@ -196,23 +197,31 @@ export default function SeriesExtensionFields(): JSX.Element | null {
 		}
 
 		const previousSeriesIds = previousSeriesIdsRef.current;
-		if ( ! isNewPost && ! postStatus ) {
-			return;
-		}
-
 		const addedIds = currentSeriesIds.filter(
 			( id ) => ! previousSeriesIds.includes( id )
 		);
 		const removedIds = previousSeriesIds.filter(
 			( id ) => ! currentSeriesIds.includes( id )
 		);
+		previousSeriesIdsRef.current = currentSeriesIds;
 
-		if ( addedIds.length === 0 && removedIds.length === 0 ) {
+		if ( addedIds.length > 0 || removedIds.length > 0 ) {
+			const pendingSet = new Set( pendingSeriesIdsRef.current );
+
+			removedIds.forEach( ( id ) => pendingSet.delete( id ) );
+			addedIds.forEach( ( id ) => pendingSet.add( id ) );
+
+			pendingSeriesIdsRef.current = Array.from( pendingSet );
+		}
+
+		if ( ! isNewPost && ! postStatus ) {
 			return;
 		}
 
-		previousSeriesIdsRef.current = currentSeriesIds;
-		if ( addedIds.length === 0 ) {
+		const pendingIds = pendingSeriesIdsRef.current.filter( ( id ) =>
+			currentSeriesIds.includes( id )
+		);
+		if ( pendingIds.length === 0 ) {
 			return;
 		}
 
@@ -224,7 +233,7 @@ export default function SeriesExtensionFields(): JSX.Element | null {
 
 			if ( shouldSuggestNextPart ) {
 				const suggestions = await Promise.all(
-					addedIds.map( async ( id ) => ( {
+					pendingIds.map( async ( id ) => ( {
 						id,
 						order: await getSuggestedOrder( id ),
 					} ) )
@@ -241,7 +250,7 @@ export default function SeriesExtensionFields(): JSX.Element | null {
 					}
 				} );
 			} else {
-				addedIds.forEach( ( id ) => {
+				pendingIds.forEach( ( id ) => {
 					if ( ! ( id in newOrder ) ) {
 						newOrder[ id ] = 1;
 						hasChanges = true;
@@ -252,6 +261,10 @@ export default function SeriesExtensionFields(): JSX.Element | null {
 			if ( hasChanges ) {
 				editPost( { series_order: newOrder } );
 			}
+
+			pendingSeriesIdsRef.current = pendingSeriesIdsRef.current.filter(
+				( id ) => ! pendingIds.includes( id )
+			);
 		};
 
 		initializeSeriesOrder();

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -6,6 +6,7 @@
 /// <reference path="./wordpress-components.d.ts" />
 /// <reference path="./wordpress-blocks.d.ts" />
 /// <reference path="./wordpress-block-editor.d.ts" />
+/// <reference path="./wordpress-hooks.d.ts" />
 
 export interface Series {
 	id: number;

--- a/src/types/wordpress-hooks.d.ts
+++ b/src/types/wordpress-hooks.d.ts
@@ -1,0 +1,8 @@
+declare module '@wordpress/hooks' {
+	export function addFilter(
+		hookName: string,
+		namespace: string,
+		callback: Function,
+		priority?: number
+	): void;
+}


### PR DESCRIPTION
## Summary
- fix series part suggestion logic so existing `series_order` values are not overwritten when opening an already-assigned draft
- initialize series tracking from resolved editor state and only apply suggestions for terms added after that baseline
- keep new draft behavior: suggest next part using `/content-series/v1/series/{id}/posts` (`highest + 1`)
- add local TypeScript module declarations for `@wordpress/hooks` and reference them from `src/types/index.d.ts` to unblock `check-types`

## Validation
- `pnpm run lint:js -- src/sidebar/series-extension-fields.tsx`
- `pnpm run check-types`
- Playwright MCP manual verification:
  - new draft with series parts `3` and `7` suggests `8`
  - existing draft with saved value `4` keeps `4` after reload (no silent overwrite)
  - fresh draft still suggests `8` for the same series

- fix race condition where rapid successive series additions could drop initialization for one term by tracking pending IDs until async initialization completes
