### PR TITLE
Implement CI checks and stricter TypeScript no-any guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+    pull_request:
+    push:
+        branches:
+            - trunk
+
+permissions:
+    contents: read
+
+jobs:
+    check-types:
+        name: TypeScript
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 9
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: pnpm
+
+            - name: Install Node dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Run TypeScript checks
+              run: pnpm check-types
+
+    phpunit:
+        name: PHPUnit
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 9
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: pnpm
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.2
+                  coverage: none
+                  tools: composer:v2
+
+            - name: Install Node dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Install Composer dependencies
+              run: composer install --no-interaction --prefer-dist
+
+            - name: Start wp-env
+              run: pnpm env:start
+
+            - name: Run PHPUnit tests
+              run: pnpm test
+
+            - name: Destroy wp-env
+              if: always()
+              run: pnpm env:destroy || true

--- a/src/types/wordpress-block-editor.d.ts
+++ b/src/types/wordpress-block-editor.d.ts
@@ -1,10 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module '@wordpress/block-editor' {
 	import type { ComponentType, ReactNode } from 'react';
 
 	export interface BlockProps {
 		className?: string;
-		[ key: string ]: any;
+		[ key: string ]: unknown;
 	}
 
 	export function useBlockProps( props?: BlockProps ): BlockProps;

--- a/src/types/wordpress-blocks.d.ts
+++ b/src/types/wordpress-blocks.d.ts
@@ -1,41 +1,58 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module '@wordpress/blocks' {
-	export interface BlockBindingsSourceConfig {
+	export interface BlockBindingsSourceConfig<
+		TGetFieldsArgs = never,
+		TGetValuesArgs = never,
+	> {
 		name: string;
 		label: string;
 		usesContext?: string[];
-		getFieldsList?: ( args: any ) => any[];
-		getValues?: ( args: any ) => Record< string, any >;
+		getFieldsList?: ( args: TGetFieldsArgs ) => unknown[];
+		getValues?: ( args: TGetValuesArgs ) => Record< string, unknown >;
 	}
 
-	export interface BlockTypeSettings {
-		edit?: React.ComponentType< any >;
+	export interface BlockTypeSettings< TProps = never > {
+		edit?: React.ComponentType< TProps >;
 		save?: () => JSX.Element | null;
-		[ key: string ]: any;
+		[ key: string ]: unknown;
 	}
 
-	export function registerBlockBindingsSource(
-		config: BlockBindingsSourceConfig
+	export interface BlockVariation<
+		TAttributes extends Record< string, unknown > = Record< string, unknown >,
+		TInnerBlocks = unknown[],
+	> {
+		name: string;
+		title?: string;
+		description?: string;
+		category?: string;
+		keywords?: string[];
+		attributes?: TAttributes;
+		isActive?: ( blockAttributes: TAttributes ) => boolean;
+		innerBlocks?: TInnerBlocks;
+		scope?: string[];
+		[ key: string ]: unknown;
+	}
+
+	export function registerBlockBindingsSource<
+		TGetFieldsArgs = never,
+		TGetValuesArgs = never,
+	>(
+		config: BlockBindingsSourceConfig< TGetFieldsArgs, TGetValuesArgs >
 	): void;
 
-	export function registerBlockType(
-		nameOrMetadata: string | { name: string; [ key: string ]: any },
-		settings?: BlockTypeSettings
+	export function registerBlockType< TProps = never >(
+		nameOrMetadata:
+			| string
+			| ( {
+					name: string;
+			  } & Record< string, unknown > ),
+		settings?: BlockTypeSettings< TProps >
 	): void;
 
-	export function registerBlockVariation(
+	export function registerBlockVariation<
+		TAttributes extends Record< string, unknown > = Record< string, unknown >,
+		TInnerBlocks = unknown[],
+	>(
 		blockName: string,
-		variation: {
-			name: string;
-			title?: string;
-			description?: string;
-			category?: string;
-			keywords?: string[];
-			attributes?: Record< string, any >;
-			isActive?: ( blockAttributes: any ) => boolean;
-			innerBlocks?: any[];
-			scope?: string[];
-			[ key: string ]: any;
-		}
+		variation: BlockVariation< TAttributes, TInnerBlocks >
 	): void;
 }

--- a/src/variations/index.ts
+++ b/src/variations/index.ts
@@ -11,6 +11,12 @@ declare const contentSeriesVariations: {
 	description: string;
 };
 
+interface TermsQueryVariationAttributes {
+	termQuery?: {
+		taxonomy?: string;
+	};
+}
+
 /**
  * Get the inner blocks structure for the variation.
  *
@@ -109,11 +115,8 @@ registerBlockVariation( 'core/terms-query', {
 			inherit: false,
 		},
 	},
-	isActive( blockAttributes: any ) {
-		return (
-			blockAttributes.termQuery &&
-			blockAttributes.termQuery.taxonomy === 'series'
-		);
+	isActive( blockAttributes: TermsQueryVariationAttributes ) {
+		return blockAttributes.termQuery?.taxonomy === 'series';
 	},
 	innerBlocks: getInnerBlocks(),
 	scope: [ 'inserter', 'block' ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"strict": true,
+		"noImplicitAny": true,
 		"forceConsistentCasingInFileNames": true,
 		"noFallthroughCasesInSwitch": true,
 		"module": "esnext",


### PR DESCRIPTION
## Summary
- add a CI workflow that runs TypeScript checks and PHPUnit on pushes/PRs
- enforce `noImplicitAny` in `tsconfig.json`
- remove explicit `any` usage from local WordPress typing shims and block variation typing

## Validation
- `pnpm check-types` passes locally
- `pnpm test` currently fails due existing nonce issue in `TaxonomyTest::test_series_term_assignment` (tracked in #22)

Closes #11