### PR TITLE
Fix CI pnpm version conflict in workflow setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 9
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -45,8 +43,6 @@ jobs:
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 9
 
             - name: Setup Node.js
               uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- remove explicit `with.version` from both `pnpm/action-setup@v4` steps in `.github/workflows/ci.yml`
- keep `package.json` `packageManager` as the single pnpm version source (`pnpm@9.0.0`)

## Why
`pnpm/action-setup@v4` fails when both workflow config and `packageManager` specify pnpm versions, which currently blocks CI before install/test steps.

## Validation
- verified workflow file now has no `version: 9` under `Setup pnpm` steps
- this change is workflow-only; GitHub Actions run on this PR will confirm end-to-end

Closes #25