### PR TITLE
Show series information on non-series archive pages

### DIFF
--- a/includes/class-templates.php
+++ b/includes/class-templates.php
@@ -19,6 +19,8 @@ class Templates {
 		add_action( 'init', array( $this, 'register_templates' ), 20 );
 		add_filter( 'get_the_archive_title', array( $this, 'series_archive_title' ) );
 		add_action( 'pre_get_posts', array( $this, 'series_catalog_query' ) );
+		add_filter( 'the_excerpt', array( $this, 'append_archive_series_information' ), 20 );
+		add_filter( 'the_content', array( $this, 'append_archive_series_information' ), 20 );
 
 		// Register rewrite rule for series catalog.
 		add_action( 'init', array( $this, 'add_rewrite_rules' ) );
@@ -184,6 +186,105 @@ class Templates {
 		}
 
 		return $title;
+	}
+
+	/**
+	 * Append series information to post excerpts/content on non-series archive pages.
+	 *
+	 * @param string $content Post excerpt/content.
+	 * @return string Post excerpt/content with series information.
+	 */
+	public function append_archive_series_information( $content ) {
+		if ( ! $this->should_append_archive_series_information() ) {
+			return $content;
+		}
+
+		$post_id = get_the_ID();
+		if ( ! $post_id ) {
+			return $content;
+		}
+
+		$series_information = self::get_archive_series_information_markup( $post_id );
+		if ( '' === $series_information ) {
+			return $content;
+		}
+
+		// Prevent duplicate output if the same filter runs on already-formatted content.
+		if ( false !== strpos( $content, 'content-series-archive-info' ) ) {
+			return $content;
+		}
+
+		return $content . $series_information;
+	}
+
+	/**
+	 * Determine whether to append series information for current loop context.
+	 *
+	 * @return bool True when series information should be appended.
+	 */
+	private function should_append_archive_series_information() {
+		if ( is_admin() || is_feed() ) {
+			return false;
+		}
+
+		if ( ! in_the_loop() || ! is_main_query() ) {
+			return false;
+		}
+
+		if ( ! ( is_archive() || is_home() || is_search() ) ) {
+			return false;
+		}
+
+		if ( is_tax( CONTENT_SERIES_TAXONOMY ) || get_query_var( 'content_series_catalog' ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Build archive series information markup for a post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string HTML markup, or empty string when no series is assigned.
+	 */
+	public static function get_archive_series_information_markup( $post_id ) {
+		$post_id = absint( $post_id );
+		if ( ! $post_id ) {
+			return '';
+		}
+
+		$series_terms = get_the_terms( $post_id, CONTENT_SERIES_TAXONOMY );
+		if ( ! $series_terms || is_wp_error( $series_terms ) ) {
+			return '';
+		}
+
+		$series_term = reset( $series_terms );
+		if ( ! $series_term instanceof \WP_Term ) {
+			return '';
+		}
+
+		$series_link = get_term_link( $series_term );
+		if ( is_wp_error( $series_link ) ) {
+			return '';
+		}
+
+		$series_part = Post_Meta::get_post_series_part( $post_id, $series_term->term_id );
+
+		/* translators: %d: series part number. */
+		$part_label = sprintf( __( 'Part %d', 'content-series' ), $series_part );
+
+		return sprintf(
+			'<p class="content-series-archive-info">' .
+				'<span class="content-series-archive-info__label">%1$s</span> ' .
+				'<a class="content-series-archive-info__link" href="%2$s">%3$s</a> ' .
+				'<span class="content-series-archive-info__part">%4$s</span>' .
+			'</p>',
+			esc_html__( 'Series:', 'content-series' ),
+			esc_url( $series_link ),
+			esc_html( $series_term->name ),
+			esc_html( $part_label )
+		);
 	}
 
 	/**

--- a/includes/class-templates.php
+++ b/includes/class-templates.php
@@ -21,6 +21,8 @@ class Templates {
 		add_action( 'pre_get_posts', array( $this, 'series_catalog_query' ) );
 		add_filter( 'the_excerpt', array( $this, 'append_archive_series_information' ), 20 );
 		add_filter( 'the_content', array( $this, 'append_archive_series_information' ), 20 );
+		add_filter( 'render_block_core/post-excerpt', array( $this, 'append_archive_series_information_for_post_block' ), 20, 2 );
+		add_filter( 'render_block_core/post-content', array( $this, 'append_archive_series_information_for_post_block' ), 20, 2 );
 
 		// Register rewrite rule for series catalog.
 		add_action( 'init', array( $this, 'add_rewrite_rules' ) );
@@ -195,7 +197,7 @@ class Templates {
 	 * @return string Post excerpt/content with series information.
 	 */
 	public function append_archive_series_information( $content ) {
-		if ( ! $this->should_append_archive_series_information() ) {
+		if ( ! $this->should_append_archive_series_information( true ) ) {
 			return $content;
 		}
 
@@ -204,8 +206,41 @@ class Templates {
 			return $content;
 		}
 
-		$series_information = self::get_archive_series_information_markup( $post_id );
-		if ( '' === $series_information ) {
+		return $this->append_archive_series_information_to_content( $content, $post_id );
+	}
+
+	/**
+	 * Append series information for core post blocks in Query Loop contexts.
+	 *
+	 * @param string $block_content Rendered block content.
+	 * @param array  $block         Parsed block data.
+	 * @return string Block content with series information.
+	 */
+	public function append_archive_series_information_for_post_block( $block_content, $block ) {
+		if ( ! $this->should_append_archive_series_information( false ) ) {
+			return $block_content;
+		}
+
+		if ( empty( $block['context']['postId'] ) ) {
+			return $block_content;
+		}
+
+		return $this->append_archive_series_information_to_content(
+			$block_content,
+			absint( $block['context']['postId'] )
+		);
+	}
+
+	/**
+	 * Append series information to a rendered content string for a given post.
+	 *
+	 * @param string $content Rendered content.
+	 * @param int    $post_id Post ID.
+	 * @return string Content with appended series information.
+	 */
+	private function append_archive_series_information_to_content( $content, $post_id ) {
+		$post_id = absint( $post_id );
+		if ( ! $post_id ) {
 			return $content;
 		}
 
@@ -214,20 +249,26 @@ class Templates {
 			return $content;
 		}
 
+		$series_information = self::get_archive_series_information_markup( $post_id );
+		if ( '' === $series_information ) {
+			return $content;
+		}
+
 		return $content . $series_information;
 	}
 
 	/**
-	 * Determine whether to append series information for current loop context.
+	 * Determine whether to append series information in the current request context.
 	 *
+	 * @param bool $require_loop_context Whether loop context checks should be required.
 	 * @return bool True when series information should be appended.
 	 */
-	private function should_append_archive_series_information() {
+	private function should_append_archive_series_information( $require_loop_context = true ) {
 		if ( is_admin() || is_feed() ) {
 			return false;
 		}
 
-		if ( ! in_the_loop() || ! is_main_query() ) {
+		if ( $require_loop_context && ( ! in_the_loop() || ! is_main_query() ) ) {
 			return false;
 		}
 

--- a/tests/TemplatesTest.php
+++ b/tests/TemplatesTest.php
@@ -17,18 +17,32 @@ use WP_UnitTestCase;
 class TemplatesTest extends WP_UnitTestCase {
 
 	/**
+	 * Create a series term with a valid nonce for test environments.
+	 *
+	 * @param string $name Series term name.
+	 * @return int Created term ID.
+	 */
+	private function create_series_term( $name ) {
+		$_POST['_wpnonce_add-tag'] = wp_create_nonce( 'add-tag' );
+
+		$term_id = $this->factory->term->create(
+			array(
+				'taxonomy' => 'series',
+				'name'     => $name,
+			)
+		);
+
+		unset( $_POST['_wpnonce_add-tag'] );
+
+		return $term_id;
+	}
+
+	/**
 	 * Test that archive series information markup is generated for series posts.
 	 */
 	public function test_archive_series_information_markup_for_series_post() {
 		$post_id = $this->factory->post->create();
-		$_POST['_wpnonce_add-tag'] = wp_create_nonce( 'add-tag' );
-		$term_id = $this->factory->term->create(
-			array(
-				'taxonomy' => 'series',
-				'name'     => 'Testing Series',
-			)
-		);
-		unset( $_POST['_wpnonce_add-tag'] );
+		$term_id = $this->create_series_term( 'Testing Series' );
 
 		wp_set_object_terms( $post_id, $term_id, 'series' );
 		Post_Meta::set_post_series_part( $post_id, $term_id, 4 );
@@ -59,5 +73,57 @@ class TemplatesTest extends WP_UnitTestCase {
 		$markup = Templates::get_archive_series_information_markup( 0 );
 
 		$this->assertSame( '', $markup );
+	}
+
+	/**
+	 * Test that block rendering appends series info in archive contexts even when not main query.
+	 */
+	public function test_post_block_append_in_non_main_archive_query() {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title'   => 'Archive Query Loop Post',
+				'post_content' => 'Post content for archive test.',
+			)
+		);
+		$term_id = $this->create_series_term( 'Block Query Series' );
+
+		wp_set_object_terms( $post_id, $term_id, 'series' );
+		Post_Meta::set_post_series_part( $post_id, $term_id, 2 );
+
+		// Set archive-like context via search page.
+		$this->go_to( '/?s=archive' );
+		$this->assertTrue( is_search() );
+
+		global $wp_query;
+		$original_wp_query = $wp_query;
+
+		$secondary_query = new \WP_Query(
+			array(
+				's' => 'archive',
+			)
+		);
+		$wp_query = $secondary_query;
+
+		try {
+			$this->assertFalse( is_main_query() );
+			$this->assertTrue( is_search() );
+
+			$templates = new Templates();
+			$content   = '<p>Rendered excerpt.</p>';
+			$block     = array(
+				'context' => array(
+					'postId' => $post_id,
+				),
+			);
+
+			$result = $templates->append_archive_series_information_for_post_block( $content, $block );
+
+			$this->assertStringContainsString( 'content-series-archive-info', $result );
+			$this->assertStringContainsString( 'Block Query Series', $result );
+			$this->assertStringContainsString( 'Part 2', $result );
+		} finally {
+			$wp_query = $original_wp_query;
+			wp_reset_postdata();
+		}
 	}
 }

--- a/tests/TemplatesTest.php
+++ b/tests/TemplatesTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests for Templates class.
+ *
+ * @package ContentSeries
+ */
+
+namespace Content_Series\Tests;
+
+use Content_Series\Post_Meta;
+use Content_Series\Templates;
+use WP_UnitTestCase;
+
+/**
+ * Test suite for Templates class.
+ */
+class TemplatesTest extends WP_UnitTestCase {
+
+	/**
+	 * Test that archive series information markup is generated for series posts.
+	 */
+	public function test_archive_series_information_markup_for_series_post() {
+		$post_id = $this->factory->post->create();
+		$_POST['_wpnonce_add-tag'] = wp_create_nonce( 'add-tag' );
+		$term_id = $this->factory->term->create(
+			array(
+				'taxonomy' => 'series',
+				'name'     => 'Testing Series',
+			)
+		);
+		unset( $_POST['_wpnonce_add-tag'] );
+
+		wp_set_object_terms( $post_id, $term_id, 'series' );
+		Post_Meta::set_post_series_part( $post_id, $term_id, 4 );
+
+		$markup = Templates::get_archive_series_information_markup( $post_id );
+
+		$this->assertNotSame( '', $markup );
+		$this->assertStringContainsString( 'content-series-archive-info', $markup );
+		$this->assertStringContainsString( 'Testing Series', $markup );
+		$this->assertStringContainsString( 'Part 4', $markup );
+	}
+
+	/**
+	 * Test that empty string is returned when post has no series.
+	 */
+	public function test_archive_series_information_markup_without_series() {
+		$post_id = $this->factory->post->create();
+
+		$markup = Templates::get_archive_series_information_markup( $post_id );
+
+		$this->assertSame( '', $markup );
+	}
+
+	/**
+	 * Test that empty string is returned for invalid post id.
+	 */
+	public function test_archive_series_information_markup_with_invalid_post_id() {
+		$markup = Templates::get_archive_series_information_markup( 0 );
+
+		$this->assertSame( '', $markup );
+	}
+}


### PR DESCRIPTION
## Summary
- append series metadata to post content/excerpts when rendering non-series archive contexts
- skip series taxonomy archive and series catalog routes to avoid duplicate or irrelevant output
- add Templates::get_archive_series_information_markup() helper and PHPUnit coverage

## Testing
- pnpm test

Closes #7