### PR TITLE
Issue #6: Convert series navigation to wrapper block with reusable inner blocks

### DIFF
--- a/includes/class-content-series.php
+++ b/includes/class-content-series.php
@@ -152,6 +152,36 @@ class Content_Series {
 				)
 			);
 		}
+
+		// Series Navigation Link block.
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'content-series/navigation-link' ) ) {
+			register_block_type_from_metadata(
+				CONTENT_SERIES_PATH . 'build/blocks/series-navigation-link',
+				array(
+					'render_callback' => array( $this, 'render_series_navigation_link' ),
+				)
+			);
+		}
+
+		// Series Title block.
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'content-series/series-title' ) ) {
+			register_block_type_from_metadata(
+				CONTENT_SERIES_PATH . 'build/blocks/series-title',
+				array(
+					'render_callback' => array( $this, 'render_series_title' ),
+				)
+			);
+		}
+
+		// Series Icon block.
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'content-series/series-icon' ) ) {
+			register_block_type_from_metadata(
+				CONTENT_SERIES_PATH . 'build/blocks/series-icon',
+				array(
+					'render_callback' => array( $this, 'render_series_icon' ),
+				)
+			);
+		}
 	}
 
 	/**
@@ -206,8 +236,14 @@ class Content_Series {
 		$render_file = CONTENT_SERIES_PATH . 'src/blocks/series-post-list/render.php';
 		if ( file_exists( $render_file ) ) {
 			ob_start();
-			include $render_file;
-			return ob_get_clean();
+			$included_output = include $render_file;
+			$buffered_output = ob_get_clean();
+
+			if ( is_string( $included_output ) ) {
+				return $included_output;
+			}
+
+			return $buffered_output;
 		}
 		return '';
 	}
@@ -225,8 +261,89 @@ class Content_Series {
 		$render_file = CONTENT_SERIES_PATH . 'src/blocks/series-navigation/render.php';
 		if ( file_exists( $render_file ) ) {
 			ob_start();
-			include $render_file;
-			return ob_get_clean();
+			$included_output = include $render_file;
+			$buffered_output = ob_get_clean();
+
+			if ( is_string( $included_output ) ) {
+				return $included_output;
+			}
+
+			return $buffered_output;
+		}
+		return '';
+	}
+
+	/**
+	 * Render Series Navigation Link block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block HTML.
+	 */
+	public function render_series_navigation_link( $attributes, $content, $block ) {
+		// Include render file.
+		$render_file = CONTENT_SERIES_PATH . 'src/blocks/series-navigation-link/render.php';
+		if ( file_exists( $render_file ) ) {
+			ob_start();
+			$included_output = include $render_file;
+			$buffered_output = ob_get_clean();
+
+			if ( is_string( $included_output ) ) {
+				return $included_output;
+			}
+
+			return $buffered_output;
+		}
+		return '';
+	}
+
+	/**
+	 * Render Series Title block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block HTML.
+	 */
+	public function render_series_title( $attributes, $content, $block ) {
+		// Include render file.
+		$render_file = CONTENT_SERIES_PATH . 'src/blocks/series-title/render.php';
+		if ( file_exists( $render_file ) ) {
+			ob_start();
+			$included_output = include $render_file;
+			$buffered_output = ob_get_clean();
+
+			if ( is_string( $included_output ) ) {
+				return $included_output;
+			}
+
+			return $buffered_output;
+		}
+		return '';
+	}
+
+	/**
+	 * Render Series Icon block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block HTML.
+	 */
+	public function render_series_icon( $attributes, $content, $block ) {
+		// Include render file.
+		$render_file = CONTENT_SERIES_PATH . 'src/blocks/series-icon/render.php';
+		if ( file_exists( $render_file ) ) {
+			ob_start();
+			$included_output = include $render_file;
+			$buffered_output = ob_get_clean();
+
+			if ( is_string( $included_output ) ) {
+				return $included_output;
+			}
+
+			return $buffered_output;
 		}
 		return '';
 	}

--- a/src/blocks/series-icon/block.json
+++ b/src/blocks/series-icon/block.json
@@ -1,0 +1,33 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "content-series/series-icon",
+	"version": "1.0.0",
+	"title": "Series Icon",
+	"category": "theme",
+	"description": "Displays the current series icon.",
+	"textdomain": "content-series",
+	"attributes": {
+		"isLink": {
+			"type": "boolean",
+			"default": true
+		},
+		"size": {
+			"type": "number",
+			"default": 40
+		},
+		"alt": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"usesContext": [ "postId", "postType" ],
+	"supports": {
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"editorScript": "file:./index.js"
+}

--- a/src/blocks/series-icon/edit.tsx
+++ b/src/blocks/series-icon/edit.tsx
@@ -1,0 +1,91 @@
+/**
+ * Series Icon Block - Edit Component
+ */
+
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+
+import type { SeriesIconBlockAttributes } from '../../types';
+
+interface EditProps {
+	attributes: SeriesIconBlockAttributes;
+	setAttributes: ( attrs: Partial< SeriesIconBlockAttributes > ) => void;
+}
+
+export default function Edit( {
+	attributes,
+	setAttributes,
+}: EditProps ): JSX.Element {
+	const { isLink, size, alt } = attributes;
+	const resolvedSize = Math.max( 16, Math.min( 256, Number( size ?? 40 ) ) );
+	const blockProps = useBlockProps( {
+		className:
+			'wp-block-content-series-series-icon wp-block-content-series-navigation__series-icon',
+	} );
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Series Icon', 'content-series' ) }>
+					<TextControl
+						label={ __( 'Icon size (px)', 'content-series' ) }
+						type="number"
+						min={ 16 }
+						max={ 256 }
+						value={ String( resolvedSize ) }
+						onChange={ ( value: string ) =>
+							setAttributes( { size: Number( value ) || 40 } )
+						}
+						__nextHasNoMarginBottom
+					/>
+					<TextControl
+						label={ __( 'Alt text', 'content-series' ) }
+						value={ alt ?? '' }
+						onChange={ ( value: string ) =>
+							setAttributes( { alt: value } )
+						}
+						help={ __(
+							'Leave empty to use a generated description.',
+							'content-series'
+						) }
+						__nextHasNoMarginBottom
+					/>
+					<ToggleControl
+						label={ __(
+							'Link to series archive',
+							'content-series'
+						) }
+						checked={ isLink ?? true }
+						onChange={ ( value: boolean ) =>
+							setAttributes( { isLink: value } )
+						}
+						__nextHasNoMarginBottom
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<div { ...blockProps }>
+				{ isLink ?? true ? (
+					<a href="https://example.com">
+						<span
+							className="wp-block-content-series-series-icon__image wp-block-content-series-navigation__icon wp-block-content-series-navigation__icon--placeholder"
+							style={ {
+								width: `${ resolvedSize }px`,
+								height: `${ resolvedSize }px`,
+							} }
+						/>
+					</a>
+				) : (
+					<span
+						className="wp-block-content-series-series-icon__image wp-block-content-series-navigation__icon wp-block-content-series-navigation__icon--placeholder"
+						style={ {
+							width: `${ resolvedSize }px`,
+							height: `${ resolvedSize }px`,
+						} }
+					/>
+				) }
+			</div>
+		</>
+	);
+}

--- a/src/blocks/series-icon/index.ts
+++ b/src/blocks/series-icon/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Series Icon Block
+ */
+
+import { registerBlockType } from '@wordpress/blocks';
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/src/blocks/series-icon/render.php
+++ b/src/blocks/series-icon/render.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Server-side rendering for the Series Icon block.
+ *
+ * @package ContentSeries
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use Content_Series\Term_Meta;
+
+require_once dirname( __DIR__ ) . '/shared/series-context.php';
+
+$content_series_context = content_series_get_series_context( $block );
+
+if ( ! $content_series_context ) {
+	return '';
+}
+
+$content_series_series = $content_series_context['series'];
+$content_series_icon   = Term_Meta::get_series_icon( $content_series_series->term_id );
+
+if ( ! $content_series_icon ) {
+	return '';
+}
+
+$content_series_is_link  = $attributes['isLink'] ?? true;
+$content_series_size     = isset( $attributes['size'] ) ? absint( $attributes['size'] ) : 40;
+$content_series_alt      = isset( $attributes['alt'] ) ? trim( (string) $attributes['alt'] ) : '';
+$content_series_term_url = get_term_link( $content_series_series );
+
+if ( $content_series_size < 16 ) {
+	$content_series_size = 16;
+}
+
+if ( $content_series_size > 256 ) {
+	$content_series_size = 256;
+}
+
+if ( '' === $content_series_alt ) {
+	/* translators: %s: series name */
+	$content_series_alt = sprintf( __( '%s icon', 'content-series' ), $content_series_series->name );
+}
+
+$content_series_wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class' => 'wp-block-content-series-series-icon wp-block-content-series-navigation__series-icon',
+	)
+);
+
+ob_start();
+?>
+<div <?php echo wp_kses_post( $content_series_wrapper_attributes ); ?>>
+	<?php if ( $content_series_is_link && ! is_wp_error( $content_series_term_url ) ) : ?>
+		<a href="<?php echo esc_url( $content_series_term_url ); ?>">
+	<?php endif; ?>
+		<img
+			src="<?php echo esc_url( $content_series_icon ); ?>"
+			alt="<?php echo esc_attr( $content_series_alt ); ?>"
+			class="wp-block-content-series-series-icon__image wp-block-content-series-navigation__icon"
+			width="<?php echo esc_attr( (string) $content_series_size ); ?>"
+			height="<?php echo esc_attr( (string) $content_series_size ); ?>"
+			loading="lazy"
+			decoding="async"
+		/>
+	<?php if ( $content_series_is_link && ! is_wp_error( $content_series_term_url ) ) : ?>
+		</a>
+	<?php endif; ?>
+</div>
+<?php
+return ob_get_clean();

--- a/src/blocks/series-navigation-link/block.json
+++ b/src/blocks/series-navigation-link/block.json
@@ -1,0 +1,40 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "content-series/navigation-link",
+	"version": "1.0.0",
+	"title": "Series Navigation Link",
+	"category": "theme",
+	"description": "Displays a previous or next series navigation link.",
+	"textdomain": "content-series",
+	"parent": [ "content-series/navigation" ],
+	"attributes": {
+		"direction": {
+			"type": "string",
+			"default": "previous",
+			"enum": [ "previous", "next" ]
+		},
+		"showTitle": {
+			"type": "boolean",
+			"default": true
+		},
+		"showPartNumbers": {
+			"type": "boolean",
+			"default": true
+		},
+		"label": {
+			"type": "string",
+			"default": ""
+		},
+		"arrowStyle": {
+			"type": "string",
+			"default": "arrow",
+			"enum": [ "arrow", "chevron", "none" ]
+		}
+	},
+	"usesContext": [ "postId", "postType" ],
+	"supports": {
+		"html": false
+	},
+	"editorScript": "file:./index.js"
+}

--- a/src/blocks/series-navigation-link/edit.test.ts
+++ b/src/blocks/series-navigation-link/edit.test.ts
@@ -1,0 +1,31 @@
+import { ARROW_STYLES, getArrowStyle } from './edit';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	InspectorControls: () => null,
+	useBlockProps: () => ( {} ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: () => null,
+	SelectControl: () => null,
+	TextControl: () => null,
+	ToggleControl: () => null,
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+describe( 'series navigation link edit helpers', () => {
+	test( 'returns configured arrow styles', () => {
+		expect( getArrowStyle( 'arrow' ) ).toEqual( ARROW_STYLES.arrow );
+		expect( getArrowStyle( 'chevron' ) ).toEqual( ARROW_STYLES.chevron );
+		expect( getArrowStyle( 'none' ) ).toEqual( ARROW_STYLES.none );
+	} );
+
+	test( 'falls back to default arrow style', () => {
+		expect( getArrowStyle( 'invalid' as never ) ).toEqual(
+			ARROW_STYLES.arrow
+		);
+	} );
+} );

--- a/src/blocks/series-navigation-link/edit.tsx
+++ b/src/blocks/series-navigation-link/edit.tsx
@@ -1,0 +1,183 @@
+/**
+ * Series Navigation Link Block - Edit Component
+ */
+
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	ToggleControl,
+	TextControl,
+	SelectControl,
+} from '@wordpress/components';
+
+import type { NavigationLinkBlockAttributes } from '../../types';
+
+interface EditProps {
+	attributes: NavigationLinkBlockAttributes;
+	setAttributes: ( attrs: Partial< NavigationLinkBlockAttributes > ) => void;
+}
+
+interface ArrowStyle {
+	prev: string;
+	next: string;
+}
+
+export const ARROW_STYLES: Record< string, ArrowStyle > = {
+	arrow: { prev: '\u2190', next: '\u2192' },
+	chevron: { prev: '\u2039', next: '\u203A' },
+	none: { prev: '', next: '' },
+};
+
+export function getArrowStyle(
+	arrowStyle: NavigationLinkBlockAttributes[ 'arrowStyle' ]
+): ArrowStyle {
+	return ARROW_STYLES[ arrowStyle ?? 'arrow' ] || ARROW_STYLES.arrow;
+}
+
+export default function Edit( {
+	attributes,
+	setAttributes,
+}: EditProps ): JSX.Element {
+	const {
+		direction = 'previous',
+		showTitle,
+		showPartNumbers,
+		label,
+		arrowStyle,
+	} = attributes;
+	const isPrevious = direction === 'previous';
+	const arrows = getArrowStyle( arrowStyle );
+	let resolvedLabel = label ?? '';
+
+	if ( ! resolvedLabel.trim() ) {
+		resolvedLabel = isPrevious
+			? __( 'Previous', 'content-series' )
+			: __( 'Next', 'content-series' );
+	}
+	const blockProps = useBlockProps( {
+		className: isPrevious
+			? 'wp-block-content-series-navigation__prev'
+			: 'wp-block-content-series-navigation__next',
+	} );
+	const samplePart = isPrevious ? 2 : 4;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Navigation Link', 'content-series' ) }>
+					<SelectControl
+						label={ __( 'Direction', 'content-series' ) }
+						value={ direction }
+						options={ [
+							{
+								label: __( 'Previous', 'content-series' ),
+								value: 'previous',
+							},
+							{
+								label: __( 'Next', 'content-series' ),
+								value: 'next',
+							},
+						] }
+						onChange={ ( value: string ) =>
+							setAttributes( {
+								direction:
+									value as NavigationLinkBlockAttributes[ 'direction' ],
+							} )
+						}
+						__nextHasNoMarginBottom
+					/>
+					<TextControl
+						label={ __( 'Label', 'content-series' ) }
+						value={ label ?? '' }
+						onChange={ ( value: string ) =>
+							setAttributes( { label: value } )
+						}
+						placeholder={
+							isPrevious
+								? __( 'Previous', 'content-series' )
+								: __( 'Next', 'content-series' )
+						}
+						__nextHasNoMarginBottom
+					/>
+					<ToggleControl
+						label={ __( 'Show post title', 'content-series' ) }
+						checked={ showTitle ?? true }
+						onChange={ ( value: boolean ) =>
+							setAttributes( { showTitle: value } )
+						}
+						__nextHasNoMarginBottom
+					/>
+					<ToggleControl
+						label={ __( 'Show part numbers', 'content-series' ) }
+						checked={ showPartNumbers ?? true }
+						onChange={ ( value: boolean ) =>
+							setAttributes( { showPartNumbers: value } )
+						}
+						__nextHasNoMarginBottom
+					/>
+					<SelectControl
+						label={ __( 'Arrow style', 'content-series' ) }
+						value={ arrowStyle ?? 'arrow' }
+						options={ [
+							{
+								label: __( 'Arrows (← →)', 'content-series' ),
+								value: 'arrow',
+							},
+							{
+								label: __( 'Chevrons (‹ ›)', 'content-series' ),
+								value: 'chevron',
+							},
+							{
+								label: __( 'None', 'content-series' ),
+								value: 'none',
+							},
+						] }
+						onChange={ ( value: string ) =>
+							setAttributes( {
+								arrowStyle:
+									value as NavigationLinkBlockAttributes[ 'arrowStyle' ],
+							} )
+						}
+						__nextHasNoMarginBottom
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<div { ...blockProps }>
+				<a href="https://example.com">
+					{ isPrevious && arrows.prev && (
+						<span className="wp-block-content-series-navigation__arrow">
+							{ arrows.prev }
+						</span>
+					) }
+					<span className="wp-block-content-series-navigation__text">
+						<span className="wp-block-content-series-navigation__label">
+							{ resolvedLabel }
+							{ ( showPartNumbers ?? true ) &&
+								` (Part ${ samplePart })` }
+						</span>
+						{ ( showTitle ?? true ) && (
+							<span className="wp-block-content-series-navigation__title">
+								{ isPrevious
+									? __(
+											'Previous post title',
+											'content-series'
+									  )
+									: __(
+											'Next post title',
+											'content-series'
+									  ) }
+							</span>
+						) }
+					</span>
+					{ ! isPrevious && arrows.next && (
+						<span className="wp-block-content-series-navigation__arrow">
+							{ arrows.next }
+						</span>
+					) }
+				</a>
+			</div>
+		</>
+	);
+}

--- a/src/blocks/series-navigation-link/index.ts
+++ b/src/blocks/series-navigation-link/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Series Navigation Link Block
+ */
+
+import { registerBlockType } from '@wordpress/blocks';
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/src/blocks/series-navigation-link/render.php
+++ b/src/blocks/series-navigation-link/render.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Server-side rendering for the Series Navigation Link block.
+ *
+ * @package ContentSeries
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use Content_Series\Post_Meta;
+
+require_once dirname( __DIR__ ) . '/shared/series-context.php';
+
+$content_series_direction = $attributes['direction'] ?? 'previous';
+
+if ( ! in_array( $content_series_direction, array( 'previous', 'next' ), true ) ) {
+	return '';
+}
+
+$content_series_context = content_series_get_series_context( $block );
+
+if ( ! $content_series_context ) {
+	return '';
+}
+
+$content_series_series      = $content_series_context['series'];
+$content_series_is_previous = 'previous' === $content_series_direction;
+$content_series_target_post = $content_series_is_previous
+	? $content_series_context['prev_post']
+	: $content_series_context['next_post'];
+$content_series_class_name  = $content_series_is_previous
+	? 'wp-block-content-series-navigation__prev'
+	: 'wp-block-content-series-navigation__next';
+
+$content_series_wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class' => $content_series_class_name,
+	)
+);
+
+if ( ! $content_series_target_post ) {
+	ob_start();
+	?>
+	<div <?php echo wp_kses_post( $content_series_wrapper_attributes ); ?>>
+		<span class="wp-block-content-series-navigation__placeholder">&nbsp;</span>
+	</div>
+	<?php
+	return ob_get_clean();
+}
+
+$content_series_show_title        = $attributes['showTitle'] ?? true;
+$content_series_show_part_numbers = $attributes['showPartNumbers'] ?? true;
+$content_series_label             = isset( $attributes['label'] ) ? trim( (string) $attributes['label'] ) : '';
+$content_series_arrow_style       = $attributes['arrowStyle'] ?? 'arrow';
+
+if ( '' === $content_series_label ) {
+	$content_series_label = $content_series_is_previous
+		? __( 'Previous', 'content-series' )
+		: __( 'Next', 'content-series' );
+}
+
+$content_series_arrows = array(
+	'arrow'   => array(
+		'prev' => '←',
+		'next' => '→',
+	),
+	'chevron' => array(
+		'prev' => '‹',
+		'next' => '›',
+	),
+	'none'    => array(
+		'prev' => '',
+		'next' => '',
+	),
+);
+
+$content_series_arrow = $content_series_arrows[ $content_series_arrow_style ] ?? $content_series_arrows['arrow'];
+$content_series_part  = Post_Meta::get_post_series_part( $content_series_target_post->ID, $content_series_series->term_id );
+
+ob_start();
+?>
+<div <?php echo wp_kses_post( $content_series_wrapper_attributes ); ?>>
+	<a href="<?php echo esc_url( get_permalink( $content_series_target_post->ID ) ); ?>">
+		<?php if ( $content_series_is_previous && $content_series_arrow['prev'] ) : ?>
+			<span class="wp-block-content-series-navigation__arrow">
+				<?php echo esc_html( $content_series_arrow['prev'] ); ?>
+			</span>
+		<?php endif; ?>
+
+		<span class="wp-block-content-series-navigation__text">
+			<span class="wp-block-content-series-navigation__label">
+				<?php
+				echo esc_html( $content_series_label );
+				if ( $content_series_show_part_numbers ) {
+					/* translators: %d: part number */
+					echo esc_html( sprintf( __( ' (Part %d)', 'content-series' ), $content_series_part ) );
+				}
+				?>
+			</span>
+
+			<?php if ( $content_series_show_title ) : ?>
+				<span class="wp-block-content-series-navigation__title">
+					<?php echo esc_html( get_the_title( $content_series_target_post->ID ) ); ?>
+				</span>
+			<?php endif; ?>
+		</span>
+
+		<?php if ( ! $content_series_is_previous && $content_series_arrow['next'] ) : ?>
+			<span class="wp-block-content-series-navigation__arrow">
+				<?php echo esc_html( $content_series_arrow['next'] ); ?>
+			</span>
+		<?php endif; ?>
+	</a>
+</div>
+<?php
+return ob_get_clean();

--- a/src/blocks/series-navigation/block.json
+++ b/src/blocks/series-navigation/block.json
@@ -5,36 +5,14 @@
 	"version": "1.0.0",
 	"title": "Series Navigation",
 	"category": "theme",
-	"description": "Displays previous/next navigation links within a series.",
+	"description": "Wrapper block for previous/next navigation, series title, and series icon.",
 	"textdomain": "content-series",
-	"attributes": {
-		"showTitle": {
-			"type": "boolean",
-			"default": true
-		},
-		"showSeriesName": {
-			"type": "boolean",
-			"default": false
-		},
-		"showPartNumbers": {
-			"type": "boolean",
-			"default": true
-		},
-		"prevLabel": {
-			"type": "string",
-			"default": "Previous"
-		},
-		"nextLabel": {
-			"type": "string",
-			"default": "Next"
-		},
-		"arrowStyle": {
-			"type": "string",
-			"default": "arrow",
-			"enum": [ "arrow", "chevron", "none" ]
-		}
-	},
 	"usesContext": [ "postId", "postType" ],
+	"allowedBlocks": [
+		"content-series/navigation-link",
+		"content-series/series-title",
+		"content-series/series-icon"
+	],
 	"supports": {
 		"html": false,
 		"color": {

--- a/src/blocks/series-navigation/edit.test.ts
+++ b/src/blocks/series-navigation/edit.test.ts
@@ -1,143 +1,39 @@
 import {
-	ARROW_STYLES,
-	getArrowStyle,
-	getNavigationPosts,
-	getNavigationViewState,
+	NAVIGATION_ALLOWED_BLOCKS,
+	NAVIGATION_TEMPLATE,
+	getNavigationTemplate,
 } from './edit';
 
-import type { SeriesData } from '../../types';
-
-jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 jest.mock( '@wordpress/block-editor', () => ( {
-	InspectorControls: () => null,
+	InnerBlocks: Object.assign( () => null, {
+		Content: () => null,
+	} ),
 	useBlockProps: () => ( {} ),
 } ) );
-jest.mock( '@wordpress/components', () => ( {
-	PanelBody: () => null,
-	Placeholder: () => null,
-	SelectControl: () => null,
-	Spinner: () => null,
-	TextControl: () => null,
-	ToggleControl: () => null,
-} ) );
-jest.mock( '@wordpress/core-data', () => ( { store: {} } ) );
-jest.mock( '@wordpress/data', () => ( { useSelect: () => ( {} ) } ) );
-jest.mock( '@wordpress/element', () => ( {
-	useEffect: () => undefined,
-	useState: ( value: unknown ) => [ value, jest.fn() ],
-} ) );
-jest.mock( '@wordpress/i18n', () => ( {
-	__: ( text: string ) => text,
-} ) );
 
-describe( 'series navigation edit helpers', () => {
-	const data: SeriesData = {
-		series: {
-			id: 1,
-			name: 'Test Series',
-			slug: 'test-series',
-			description: '',
-			count: 3,
-		},
-		posts: [
-			{
-				id: 10,
-				title: 'Part 1',
-				url: '/part-1',
-				series_part: 1,
-				status: 'publish',
-				date: '2026-01-01T00:00:00',
-			},
-			{
-				id: 20,
-				title: 'Part 2',
-				url: '/part-2',
-				series_part: 2,
-				status: 'publish',
-				date: '2026-01-02T00:00:00',
-			},
-			{
-				id: 30,
-				title: 'Part 3',
-				url: '/part-3',
-				series_part: 3,
-				status: 'publish',
-				date: '2026-01-03T00:00:00',
-			},
-		],
-	};
-
-	test( 'finds previous and next posts for the current post', () => {
-		const nav = getNavigationPosts( data, 20 );
-
-		expect( nav.prev?.id ).toBe( 10 );
-		expect( nav.next?.id ).toBe( 30 );
+describe( 'series navigation wrapper edit helpers', () => {
+	test( 'exposes expected allowed inner blocks', () => {
+		expect( NAVIGATION_ALLOWED_BLOCKS ).toEqual( [
+			'content-series/navigation-link',
+			'content-series/series-title',
+			'content-series/series-icon',
+		] );
 	} );
 
-	test( 'returns no navigation when the post is missing from the series', () => {
-		const nav = getNavigationPosts( data, 999 );
-
-		expect( nav.prev ).toBeNull();
-		expect( nav.next ).toBeNull();
+	test( 'provides a default template with previous, title, and next blocks', () => {
+		expect( NAVIGATION_TEMPLATE ).toEqual( [
+			[ 'content-series/navigation-link', { direction: 'previous' } ],
+			[ 'content-series/series-title', {} ],
+			[ 'content-series/navigation-link', { direction: 'next' } ],
+		] );
 	} );
 
-	test( 'resolves view state transitions correctly', () => {
-		expect(
-			getNavigationViewState( {
-				isLoading: true,
-				series: [ 1 ],
-				error: null,
-				prev: null,
-				next: null,
-			} )
-		).toBe( 'loading' );
+	test( 'returns a cloned template structure', () => {
+		const first = getNavigationTemplate();
+		const second = getNavigationTemplate();
 
-		expect(
-			getNavigationViewState( {
-				isLoading: false,
-				series: [],
-				error: null,
-				prev: null,
-				next: null,
-			} )
-		).toBe( 'no-series' );
-
-		expect(
-			getNavigationViewState( {
-				isLoading: false,
-				series: [ 1 ],
-				error: 'failed',
-				prev: null,
-				next: null,
-			} )
-		).toBe( 'error' );
-
-		expect(
-			getNavigationViewState( {
-				isLoading: false,
-				series: [ 1 ],
-				error: null,
-				prev: null,
-				next: null,
-			} )
-		).toBe( 'no-navigation' );
-
-		expect(
-			getNavigationViewState( {
-				isLoading: false,
-				series: [ 1 ],
-				error: null,
-				prev: data.posts[ 0 ],
-				next: null,
-			} )
-		).toBe( 'ready' );
-	} );
-
-	test( 'returns configured arrow styles and falls back to defaults', () => {
-		expect( getArrowStyle( 'chevron' ) ).toEqual( ARROW_STYLES.chevron );
-		expect( getArrowStyle( 'none' ) ).toEqual( ARROW_STYLES.none );
-		expect( getArrowStyle( 'invalid' as never ) ).toEqual(
-			ARROW_STYLES.arrow
-		);
+		expect( first ).toEqual( second );
+		expect( first ).not.toBe( second );
+		expect( first[ 0 ][ 1 ] ).not.toBe( second[ 0 ][ 1 ] );
 	} );
 } );

--- a/src/blocks/series-navigation/edit.tsx
+++ b/src/blocks/series-navigation/edit.tsx
@@ -1,408 +1,52 @@
 /**
- * Series Navigation Block - Edit Component
+ * Series Navigation Wrapper Block - Edit Component
  */
 
-import { __ } from '@wordpress/i18n';
-import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import {
-	PanelBody,
-	ToggleControl,
-	TextControl,
-	SelectControl,
-	Placeholder,
-	Spinner,
-} from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
-import apiFetch from '@wordpress/api-fetch';
-import { useState, useEffect } from '@wordpress/element';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
-import type {
-	NavigationBlockAttributes,
-	BlockContext,
-	SeriesData,
-	SeriesPost,
-	SeriesOrder,
-	WPPost,
-} from '../../types';
+export const NAVIGATION_ALLOWED_BLOCKS: string[] = [
+	'content-series/navigation-link',
+	'content-series/series-title',
+	'content-series/series-icon',
+];
 
-interface EditProps {
-	attributes: NavigationBlockAttributes;
-	setAttributes: ( attrs: Partial< NavigationBlockAttributes > ) => void;
-	context: BlockContext;
-}
-
-interface ArrowStyle {
-	prev: string;
-	next: string;
-}
-
-export const ARROW_STYLES: Record< string, ArrowStyle > = {
-	arrow: { prev: '\u2190', next: '\u2192' }, // ← →
-	chevron: { prev: '\u2039', next: '\u203A' }, // ‹ ›
-	none: { prev: '', next: '' },
-};
-
-interface NavigationViewStateArgs {
-	isLoading: boolean;
-	series?: number[];
-	error: string | null;
-	prev: SeriesPost | null;
-	next: SeriesPost | null;
-}
-
-export function getNavigationPosts(
-	seriesData: SeriesData | null,
-	postId?: number
-): {
-	prev: SeriesPost | null;
-	next: SeriesPost | null;
-} {
-	if ( ! seriesData || ! seriesData.posts || ! postId ) {
-		return { prev: null, next: null };
-	}
-
-	const currentIndex = seriesData.posts.findIndex( ( p ) => p.id === postId );
-
-	if ( currentIndex === -1 ) {
-		return { prev: null, next: null };
-	}
-
-	return {
-		prev: currentIndex > 0 ? seriesData.posts[ currentIndex - 1 ] : null,
-		next:
-			currentIndex < seriesData.posts.length - 1
-				? seriesData.posts[ currentIndex + 1 ]
-				: null,
-	};
-}
-
-export function getNavigationViewState( {
-	isLoading,
-	series,
-	error,
-	prev,
-	next,
-}: NavigationViewStateArgs ):
-	| 'loading'
-	| 'no-series'
-	| 'error'
-	| 'no-navigation'
-	| 'ready' {
-	if ( isLoading ) {
-		return 'loading';
-	}
-
-	if ( ! series || series.length === 0 ) {
-		return 'no-series';
-	}
-
-	if ( error ) {
-		return 'error';
-	}
-
-	if ( ! prev && ! next ) {
-		return 'no-navigation';
-	}
-
-	return 'ready';
-}
-
-export function getArrowStyle(
-	arrowStyle: NavigationBlockAttributes[ 'arrowStyle' ]
-): ArrowStyle {
-	return ARROW_STYLES[ arrowStyle ?? 'arrow' ] || ARROW_STYLES.arrow;
-}
-
-export default function Edit( {
-	attributes,
-	setAttributes,
-	context,
-}: EditProps ): JSX.Element {
-	const {
-		showTitle,
-		showSeriesName,
-		showPartNumbers,
-		prevLabel,
-		nextLabel,
-		arrowStyle,
-	} = attributes;
-
-	const postId = context.postId;
-	const [ seriesData, setSeriesData ] = useState< SeriesData | null >( null );
-	const [ isLoading, setIsLoading ] = useState< boolean >( true );
-	const [ error, setError ] = useState< string | null >( null );
-
-	// Get the post's series
-	const { series } = useSelect(
-		( select ): { series: number[]; seriesOrder: SeriesOrder } => {
-			if ( ! postId ) {
-				return { series: [], seriesOrder: {} };
-			}
-
-			const coreSelectors = select( coreStore ) as {
-				getEntityRecord: (
-					kind: string,
-					name: string,
-					id: number
-				) => WPPost | undefined;
-			};
-
-			const post = coreSelectors.getEntityRecord(
-				'postType',
-				'post',
-				postId
-			);
-
-			if ( ! post || ! post.series || post.series.length === 0 ) {
-				return { series: [], seriesOrder: {} };
-			}
-
-			return {
-				series: post.series,
-				seriesOrder: post.series_order || {},
-			};
+export const NAVIGATION_TEMPLATE: Array< unknown[] > = [
+	[
+		'content-series/navigation-link',
+		{
+			direction: 'previous',
 		},
-		[ postId ]
-	);
+	],
+	[ 'content-series/series-title', {} ],
+	[
+		'content-series/navigation-link',
+		{
+			direction: 'next',
+		},
+	],
+];
 
-	// Fetch series posts when we have a series
-	useEffect( () => {
-		if ( ! series || series.length === 0 ) {
-			setIsLoading( false );
-			setSeriesData( null );
-			return;
-		}
+export function getNavigationTemplate(): Array< unknown[] > {
+	// Return a fresh structure so block editor template mutations do not leak.
+	return NAVIGATION_TEMPLATE.map( ( block ) => [
+		block[ 0 ],
+		{ ...( block[ 1 ] as Record< string, unknown > ) },
+	] );
+}
 
-		const fetchSeriesData = async (): Promise< void > => {
-			setIsLoading( true );
-			setError( null );
-
-			try {
-				const data = await apiFetch< SeriesData >( {
-					path: `/content-series/v1/series/${ series[ 0 ] }/posts`,
-				} );
-				setSeriesData( data );
-			} catch ( err ) {
-				setError( ( err as Error ).message );
-			}
-
-			setIsLoading( false );
-		};
-
-		fetchSeriesData();
-	}, [ series ] );
-
+export default function Edit(): JSX.Element {
 	const blockProps = useBlockProps( {
 		className: 'wp-block-content-series-navigation',
 	} );
 
-	const { prev, next } = getNavigationPosts( seriesData, postId );
-	const viewState = getNavigationViewState( {
-		isLoading,
-		series,
-		error,
-		prev,
-		next,
-	} );
-	const arrows = getArrowStyle( arrowStyle );
-
-	// Loading state
-	if ( viewState === 'loading' ) {
-		return (
-			<div { ...blockProps }>
-				<Placeholder
-					icon="leftright"
-					label={ __( 'Series Navigation', 'content-series' ) }
-				>
-					<Spinner />
-				</Placeholder>
-			</div>
-		);
-	}
-
-	// No series
-	if ( viewState === 'no-series' ) {
-		return (
-			<div { ...blockProps }>
-				<Placeholder
-					icon="leftright"
-					label={ __( 'Series Navigation', 'content-series' ) }
-					instructions={ __(
-						'This post is not part of a series. Add it to a series in the sidebar to display navigation.',
-						'content-series'
-					) }
-				/>
-			</div>
-		);
-	}
-
-	// Error state
-	if ( viewState === 'error' ) {
-		return (
-			<div { ...blockProps }>
-				<Placeholder
-					icon="warning"
-					label={ __( 'Series Navigation', 'content-series' ) }
-					instructions={ error ?? undefined }
-				/>
-			</div>
-		);
-	}
-
-	// No navigation needed (only post in series or not found)
-	if ( viewState === 'no-navigation' ) {
-		return (
-			<div { ...blockProps }>
-				<Placeholder
-					icon="leftright"
-					label={ __( 'Series Navigation', 'content-series' ) }
-					instructions={ __(
-						'This is the only post in the series, or the post was not found in the series order.',
-						'content-series'
-					) }
-				/>
-			</div>
-		);
-	}
-
 	return (
-		<>
-			<InspectorControls>
-				<PanelBody title={ __( 'Display Settings', 'content-series' ) }>
-					<ToggleControl
-						label={ __( 'Show post title', 'content-series' ) }
-						checked={ showTitle ?? true }
-						onChange={ ( value: boolean ) =>
-							setAttributes( { showTitle: value } )
-						}
-						__nextHasNoMarginBottom
-					/>
-					<ToggleControl
-						label={ __( 'Show series name', 'content-series' ) }
-						checked={ showSeriesName ?? false }
-						onChange={ ( value: boolean ) =>
-							setAttributes( { showSeriesName: value } )
-						}
-						__nextHasNoMarginBottom
-					/>
-					<ToggleControl
-						label={ __( 'Show part numbers', 'content-series' ) }
-						checked={ showPartNumbers ?? true }
-						onChange={ ( value: boolean ) =>
-							setAttributes( { showPartNumbers: value } )
-						}
-						__nextHasNoMarginBottom
-					/>
-					<SelectControl
-						label={ __( 'Arrow style', 'content-series' ) }
-						value={ arrowStyle ?? 'arrow' }
-						options={ [
-							{
-								label: __( 'Arrows (← →)', 'content-series' ),
-								value: 'arrow',
-							},
-							{
-								label: __( 'Chevrons (‹ ›)', 'content-series' ),
-								value: 'chevron',
-							},
-							{
-								label: __( 'None', 'content-series' ),
-								value: 'none',
-							},
-						] }
-						onChange={ ( value: string ) =>
-							setAttributes( {
-								arrowStyle:
-									value as NavigationBlockAttributes[ 'arrowStyle' ],
-							} )
-						}
-						__nextHasNoMarginBottom
-					/>
-				</PanelBody>
-				<PanelBody title={ __( 'Labels', 'content-series' ) }>
-					<TextControl
-						label={ __( 'Previous label', 'content-series' ) }
-						value={ prevLabel ?? 'Previous' }
-						onChange={ ( value: string ) =>
-							setAttributes( { prevLabel: value } )
-						}
-						__nextHasNoMarginBottom
-					/>
-					<TextControl
-						label={ __( 'Next label', 'content-series' ) }
-						value={ nextLabel ?? 'Next' }
-						onChange={ ( value: string ) =>
-							setAttributes( { nextLabel: value } )
-						}
-						__nextHasNoMarginBottom
-					/>
-				</PanelBody>
-			</InspectorControls>
-
-			<nav { ...blockProps }>
-				<div className="wp-block-content-series-navigation__prev">
-					{ prev ? (
-						<a href={ prev.url }>
-							{ arrows.prev && (
-								<span className="wp-block-content-series-navigation__arrow">
-									{ arrows.prev }
-								</span>
-							) }
-							<span className="wp-block-content-series-navigation__text">
-								<span className="wp-block-content-series-navigation__label">
-									{ prevLabel ?? 'Previous' }
-									{ showPartNumbers &&
-										` (Part ${ prev.series_part })` }
-								</span>
-								{ showTitle && (
-									<span className="wp-block-content-series-navigation__title">
-										{ prev.title }
-									</span>
-								) }
-							</span>
-						</a>
-					) : (
-						<span className="wp-block-content-series-navigation__placeholder">
-							&nbsp;
-						</span>
-					) }
-				</div>
-
-				{ showSeriesName && seriesData && (
-					<div className="wp-block-content-series-navigation__series">
-						<span>{ seriesData.series.name }</span>
-					</div>
-				) }
-
-				<div className="wp-block-content-series-navigation__next">
-					{ next ? (
-						<a href={ next.url }>
-							<span className="wp-block-content-series-navigation__text">
-								<span className="wp-block-content-series-navigation__label">
-									{ nextLabel ?? 'Next' }
-									{ showPartNumbers &&
-										` (Part ${ next.series_part })` }
-								</span>
-								{ showTitle && (
-									<span className="wp-block-content-series-navigation__title">
-										{ next.title }
-									</span>
-								) }
-							</span>
-							{ arrows.next && (
-								<span className="wp-block-content-series-navigation__arrow">
-									{ arrows.next }
-								</span>
-							) }
-						</a>
-					) : (
-						<span className="wp-block-content-series-navigation__placeholder">
-							&nbsp;
-						</span>
-					) }
-				</div>
-			</nav>
-		</>
+		<nav { ...blockProps }>
+			<InnerBlocks
+				allowedBlocks={ NAVIGATION_ALLOWED_BLOCKS }
+				template={ getNavigationTemplate() }
+				templateLock={ false }
+				orientation="horizontal"
+			/>
+		</nav>
 	);
 }

--- a/src/blocks/series-navigation/index.tsx
+++ b/src/blocks/series-navigation/index.tsx
@@ -1,8 +1,9 @@
 /**
- * Series Navigation Block
+ * Series Navigation Wrapper Block
  */
 
 import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/block-editor';
 import Edit from './edit';
 import metadata from './block.json';
 
@@ -11,6 +12,5 @@ import './editor.scss';
 
 registerBlockType( metadata.name, {
 	edit: Edit,
-	// Server-side rendering only
-	save: () => null,
+	save: () => <InnerBlocks.Content />,
 } );

--- a/src/blocks/series-navigation/render.php
+++ b/src/blocks/series-navigation/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Server-side rendering for the Series Navigation block.
+ * Server-side rendering for the Series Navigation wrapper block.
  *
  * @package ContentSeries
  *
@@ -9,78 +9,7 @@
  * @var WP_Block $block      Block instance.
  */
 
-use Content_Series\Post_Meta;
-use Content_Series\Term_Meta;
-use Content_Series\Rest_API;
-
-// Get the current post ID from context.
-$content_series_post_id = $block->context['postId'] ?? get_the_ID();
-
-if ( ! $content_series_post_id ) {
-	return '';
-}
-
-// Get the post's series.
-$content_series_terms = get_the_terms( $content_series_post_id, CONTENT_SERIES_TAXONOMY );
-
-if ( ! $content_series_terms || is_wp_error( $content_series_terms ) ) {
-	// Not in a series, render nothing.
-	return '';
-}
-
-// Use the first series (primary).
-$content_series_series = $content_series_terms[0];
-
-// Get posts in the series.
-$content_series_posts = Rest_API::query_series_posts( $content_series_series->term_id );
-
-// Find current post index.
-$content_series_current_index = -1;
-
-foreach ( $content_series_posts as $content_series_index => $content_series_post ) {
-	if ( $content_series_post->ID === $content_series_post_id ) {
-		$content_series_current_index = $content_series_index;
-		break;
-	}
-}
-
-if ( -1 === $content_series_current_index ) {
-	return '';
-}
-
-// Get prev/next posts.
-$content_series_prev_post = $content_series_current_index > 0 ? $content_series_posts[ $content_series_current_index - 1 ] : null;
-$content_series_next_post = $content_series_current_index < count( $content_series_posts ) - 1 ? $content_series_posts[ $content_series_current_index + 1 ] : null;
-
-// If no navigation needed, return empty.
-if ( ! $content_series_prev_post && ! $content_series_next_post ) {
-	return '';
-}
-
-// Block attributes.
-$content_series_show_title        = $attributes['showTitle'] ?? true;
-$content_series_show_series_name  = $attributes['showSeriesName'] ?? false;
-$content_series_show_part_numbers = $attributes['showPartNumbers'] ?? true;
-$content_series_prev_label        = $attributes['prevLabel'] ?? __( 'Previous', 'content-series' );
-$content_series_next_label        = $attributes['nextLabel'] ?? __( 'Next', 'content-series' );
-$content_series_arrow_style       = $attributes['arrowStyle'] ?? 'arrow';
-
-// Arrow characters.
-$content_series_arrows = array(
-	'arrow'   => array(
-		'prev' => '←',
-		'next' => '→',
-	),
-	'chevron' => array(
-		'prev' => '‹',
-		'next' => '›',
-	),
-	'none'    => array(
-		'prev' => '',
-		'next' => '',
-	),
-);
-$content_series_arrow  = $content_series_arrows[ $content_series_arrow_style ] ?? $content_series_arrows['arrow'];
+require_once dirname( __DIR__ ) . '/shared/series-context.php';
 
 // Build wrapper attributes.
 $content_series_wrapper_attributes = get_block_wrapper_attributes(
@@ -89,79 +18,34 @@ $content_series_wrapper_attributes = get_block_wrapper_attributes(
 	)
 );
 
+$content_series_post_id = content_series_resolve_post_id( $block );
+
+if ( ! $content_series_post_id ) {
+	return '';
+}
+
+$content_series_render_context = array_merge(
+	$block->context,
+	array(
+		'postId'   => $content_series_post_id,
+		'postType' => get_post_type( $content_series_post_id ) ?: 'post',
+	)
+);
+
+$content_series_inner_html = '';
+
+foreach ( $block->parsed_block['innerBlocks'] ?? array() as $content_series_inner_block ) {
+	$content_series_inner_html .= ( new WP_Block( $content_series_inner_block, $content_series_render_context ) )->render();
+}
+
+if ( '' === trim( wp_strip_all_tags( $content_series_inner_html ) ) ) {
+	return '';
+}
+
+ob_start();
 ?>
 <nav <?php echo wp_kses_post( $content_series_wrapper_attributes ); ?>>
-	<div class="wp-block-content-series-navigation__prev">
-		<?php
-		if ( $content_series_prev_post ) :
-			$content_series_prev_part = Post_Meta::get_post_series_part( $content_series_prev_post->ID, $content_series_series->term_id );
-			?>
-			<a href="<?php echo esc_url( get_permalink( $content_series_prev_post->ID ) ); ?>">
-				<?php if ( $content_series_arrow['prev'] ) : ?>
-					<span class="wp-block-content-series-navigation__arrow">
-						<?php echo esc_html( $content_series_arrow['prev'] ); ?>
-					</span>
-				<?php endif; ?>
-				<span class="wp-block-content-series-navigation__text">
-					<span class="wp-block-content-series-navigation__label">
-						<?php
-						echo esc_html( $content_series_prev_label );
-						if ( $content_series_show_part_numbers ) {
-							/* translators: %d: part number */
-							echo esc_html( sprintf( ' (Part %d)', $content_series_prev_part ) );
-						}
-						?>
-					</span>
-					<?php if ( $content_series_show_title ) : ?>
-						<span class="wp-block-content-series-navigation__title">
-							<?php echo esc_html( get_the_title( $content_series_prev_post->ID ) ); ?>
-						</span>
-					<?php endif; ?>
-				</span>
-			</a>
-		<?php else : ?>
-			<span class="wp-block-content-series-navigation__placeholder">&nbsp;</span>
-		<?php endif; ?>
-	</div>
-
-	<?php if ( $content_series_show_series_name ) : ?>
-		<div class="wp-block-content-series-navigation__series">
-			<a href="<?php echo esc_url( get_term_link( $content_series_series ) ); ?>">
-				<?php echo esc_html( $content_series_series->name ); ?>
-			</a>
-		</div>
-	<?php endif; ?>
-
-	<div class="wp-block-content-series-navigation__next">
-		<?php
-		if ( $content_series_next_post ) :
-			$content_series_next_part = Post_Meta::get_post_series_part( $content_series_next_post->ID, $content_series_series->term_id );
-			?>
-			<a href="<?php echo esc_url( get_permalink( $content_series_next_post->ID ) ); ?>">
-				<span class="wp-block-content-series-navigation__text">
-					<span class="wp-block-content-series-navigation__label">
-						<?php
-						echo esc_html( $content_series_next_label );
-						if ( $content_series_show_part_numbers ) {
-							/* translators: %d: part number */
-							echo esc_html( sprintf( ' (Part %d)', $content_series_next_part ) );
-						}
-						?>
-					</span>
-					<?php if ( $content_series_show_title ) : ?>
-						<span class="wp-block-content-series-navigation__title">
-							<?php echo esc_html( get_the_title( $content_series_next_post->ID ) ); ?>
-						</span>
-					<?php endif; ?>
-				</span>
-				<?php if ( $content_series_arrow['next'] ) : ?>
-					<span class="wp-block-content-series-navigation__arrow">
-						<?php echo esc_html( $content_series_arrow['next'] ); ?>
-					</span>
-				<?php endif; ?>
-			</a>
-		<?php else : ?>
-			<span class="wp-block-content-series-navigation__placeholder">&nbsp;</span>
-		<?php endif; ?>
-	</div>
+	<?php echo $content_series_inner_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 </nav>
+<?php
+return ob_get_clean();

--- a/src/blocks/series-navigation/style.scss
+++ b/src/blocks/series-navigation/style.scss
@@ -43,6 +43,12 @@
 		text-align: center;
 		font-weight: 500;
 
+		.wp-block-content-series-title__heading {
+			margin: 0;
+			font-size: inherit;
+			font-weight: inherit;
+		}
+
 		a,
 		span {
 			text-decoration: none;
@@ -52,6 +58,30 @@
 		a:hover {
 			text-decoration: underline;
 		}
+	}
+
+	&__series-icon {
+		flex-shrink: 0;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+
+		a {
+			display: inline-flex;
+			align-items: center;
+		}
+	}
+
+	&__icon {
+		display: block;
+		max-width: 100%;
+		height: auto;
+		border-radius: 999px;
+	}
+
+	&__icon--placeholder {
+		border: 1px dashed #ccd0d4;
+		background: #f0f0f1;
 	}
 
 	&__arrow {
@@ -106,6 +136,10 @@
 			width: 100%;
 			padding-bottom: 0.75rem;
 			border-bottom: 1px solid #e2e4e7;
+		}
+
+		&__series-icon {
+			order: -1;
 		}
 	}
 }

--- a/src/blocks/series-post-list/render.php
+++ b/src/blocks/series-post-list/render.php
@@ -9,34 +9,17 @@
  * @var WP_Block $block      Block instance.
  */
 
-use Content_Series\Post_Meta;
-use Content_Series\Term_Meta;
-use Content_Series\Rest_API;
+require_once dirname( __DIR__ ) . '/shared/series-context.php';
 
-// Get the current post ID from context.
-$content_series_post_id = $block->context['postId'] ?? get_the_ID();
+$content_series_context = content_series_get_series_context( $block );
 
-if ( ! $content_series_post_id ) {
+if ( ! $content_series_context ) {
 	return '';
 }
 
-// Get the post's series.
-$content_series_terms = get_the_terms( $content_series_post_id, CONTENT_SERIES_TAXONOMY );
-
-if ( ! $content_series_terms || is_wp_error( $content_series_terms ) ) {
-	// Not in a series, render nothing.
-	return '';
-}
-
-// Use the first series (primary).
-$content_series_series = $content_series_terms[0];
-
-// Get posts in the series.
-$content_series_posts = Rest_API::query_series_posts( $content_series_series->term_id );
-
-if ( empty( $content_series_posts ) ) {
-	return '';
-}
+$content_series_post_id = $content_series_context['post_id'];
+$content_series_posts   = $content_series_context['posts'];
+$content_series_post_type = get_post_type( $content_series_post_id ) ?: 'post';
 
 // Block attributes.
 $content_series_show_numbers      = $attributes['showNumbers'] ?? true;
@@ -45,9 +28,6 @@ $content_series_highlight_current = $attributes['highlightCurrent'] ?? true;
 $content_series_show_series_title = $attributes['showSeriesTitle'] ?? true;
 $content_series_show_series_icon  = $attributes['showSeriesIcon'] ?? true;
 
-// Get series icon.
-$content_series_icon = Term_Meta::get_series_icon( $content_series_series->term_id );
-
 // Build wrapper attributes.
 $content_series_wrapper_attributes = get_block_wrapper_attributes(
 	array(
@@ -55,22 +35,58 @@ $content_series_wrapper_attributes = get_block_wrapper_attributes(
 	)
 );
 
+$content_series_render_child_block = static function ( $block_name, $block_attributes, $context ) {
+	$parsed_block = array(
+		'blockName'    => $block_name,
+		'attrs'        => $block_attributes,
+		'innerBlocks'  => array(),
+		'innerHTML'    => '',
+		'innerContent' => array(),
+	);
+
+	$block_instance = new WP_Block( $parsed_block, $context );
+	return $block_instance->render();
+};
+
+$content_series_render_context = array_merge(
+	$block->context,
+	array(
+		'postId'   => $content_series_post_id,
+		'postType' => $content_series_post_type,
+	)
+);
+
+$content_series_header_markup = '';
+
+if ( $content_series_show_series_title ) {
+	if ( $content_series_show_series_icon ) {
+		$content_series_header_markup .= $content_series_render_child_block(
+			'content-series/series-icon',
+			array(
+				'isLink'    => true,
+				'size'      => 60,
+				'className' => 'wp-block-content-series-post-list__icon',
+			),
+			$content_series_render_context
+		);
+	}
+
+	$content_series_header_markup .= $content_series_render_child_block(
+		'content-series/series-title',
+		array(
+			'isLink'    => true,
+			'level'     => 3,
+			'className' => 'wp-block-content-series-post-list__title',
+		),
+		$content_series_render_context
+	);
+}
+
 ?>
 <div <?php echo wp_kses_post( $content_series_wrapper_attributes ); ?>>
-	<?php if ( $content_series_show_series_title ) : ?>
+	<?php if ( '' !== trim( wp_strip_all_tags( $content_series_header_markup ) ) ) : ?>
 		<div class="wp-block-content-series-post-list__header">
-			<?php if ( $content_series_show_series_icon && $content_series_icon ) : ?>
-				<img
-					src="<?php echo esc_url( $content_series_icon ); ?>"
-					alt=""
-					class="wp-block-content-series-post-list__icon"
-				>
-			<?php endif; ?>
-			<h3 class="wp-block-content-series-post-list__title">
-				<a href="<?php echo esc_url( get_term_link( $content_series_series ) ); ?>">
-					<?php echo esc_html( $content_series_series->name ); ?>
-				</a>
-			</h3>
+			<?php echo $content_series_header_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		</div>
 	<?php endif; ?>
 

--- a/src/blocks/series-post-list/style.scss
+++ b/src/blocks/series-post-list/style.scss
@@ -12,15 +12,33 @@
 	}
 
 	&__icon {
-		width: 60px;
-		height: 60px;
-		object-fit: cover;
-		border-radius: 4px;
+		display: inline-flex;
+		align-items: center;
+		line-height: 0;
+
+		.wp-block-content-series-series-icon__image {
+			width: 60px;
+			height: 60px;
+			object-fit: cover;
+			border-radius: 4px;
+		}
 	}
 
 	&__title {
-		margin: 0;
-		font-size: 1.25rem;
+		.wp-block-content-series-title__heading {
+			margin: 0;
+			font-size: 1.25rem;
+		}
+
+		a,
+		span {
+			color: inherit;
+			text-decoration: none;
+		}
+
+		a:hover {
+			text-decoration: underline;
+		}
 	}
 
 	&__items {

--- a/src/blocks/series-title/block.json
+++ b/src/blocks/series-title/block.json
@@ -1,0 +1,33 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "content-series/series-title",
+	"version": "1.0.0",
+	"title": "Series Title",
+	"category": "theme",
+	"description": "Displays the current series title.",
+	"textdomain": "content-series",
+	"attributes": {
+		"isLink": {
+			"type": "boolean",
+			"default": true
+		},
+		"level": {
+			"type": "number",
+			"default": 3
+		}
+	},
+	"usesContext": [ "postId", "postType" ],
+	"supports": {
+		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		},
+		"color": {
+			"text": true,
+			"link": true
+		}
+	},
+	"editorScript": "file:./index.js"
+}

--- a/src/blocks/series-title/edit.tsx
+++ b/src/blocks/series-title/edit.tsx
@@ -1,0 +1,75 @@
+/**
+ * Series Title Block - Edit Component
+ */
+
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+
+import type { SeriesTitleBlockAttributes } from '../../types';
+
+interface EditProps {
+	attributes: SeriesTitleBlockAttributes;
+	setAttributes: ( attrs: Partial< SeriesTitleBlockAttributes > ) => void;
+}
+
+function getHeadingTag( level?: number ): keyof JSX.IntrinsicElements {
+	const normalized = Math.max( 1, Math.min( 6, Math.round( level ?? 3 ) ) );
+	return `h${ normalized }` as keyof JSX.IntrinsicElements;
+}
+
+export default function Edit( {
+	attributes,
+	setAttributes,
+}: EditProps ): JSX.Element {
+	const { isLink, level } = attributes;
+	const HeadingTag = getHeadingTag( level );
+	const blockProps = useBlockProps( {
+		className:
+			'wp-block-content-series-series-title wp-block-content-series-navigation__series',
+	} );
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Series Title', 'content-series' ) }>
+					<SelectControl
+						label={ __( 'Heading level', 'content-series' ) }
+						value={ String( level ?? 3 ) }
+						options={ [ 1, 2, 3, 4, 5, 6 ].map( ( value ) => ( {
+							label: `H${ value }`,
+							value: String( value ),
+						} ) ) }
+						onChange={ ( value: string ) =>
+							setAttributes( { level: Number( value ) } )
+						}
+						__nextHasNoMarginBottom
+					/>
+					<ToggleControl
+						label={ __(
+							'Link to series archive',
+							'content-series'
+						) }
+						checked={ isLink ?? true }
+						onChange={ ( value: boolean ) =>
+							setAttributes( { isLink: value } )
+						}
+						__nextHasNoMarginBottom
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<div { ...blockProps }>
+				<HeadingTag className="wp-block-content-series-title__heading">
+					{ isLink ?? true ? (
+						<a href="https://example.com">
+							{ __( 'Series title', 'content-series' ) }
+						</a>
+					) : (
+						<span>{ __( 'Series title', 'content-series' ) }</span>
+					) }
+				</HeadingTag>
+			</div>
+		</>
+	);
+}

--- a/src/blocks/series-title/index.ts
+++ b/src/blocks/series-title/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Series Title Block
+ */
+
+import { registerBlockType } from '@wordpress/blocks';
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/src/blocks/series-title/render.php
+++ b/src/blocks/series-title/render.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Server-side rendering for the Series Title block.
+ *
+ * @package ContentSeries
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+require_once dirname( __DIR__ ) . '/shared/series-context.php';
+
+$content_series_context = content_series_get_series_context( $block );
+
+if ( ! $content_series_context ) {
+	return '';
+}
+
+$content_series_series = $content_series_context['series'];
+$content_series_level  = isset( $attributes['level'] ) ? absint( $attributes['level'] ) : 3;
+
+if ( $content_series_level < 1 || $content_series_level > 6 ) {
+	$content_series_level = 3;
+}
+
+$content_series_tag_name = sprintf( 'h%d', $content_series_level );
+$content_series_is_link  = $attributes['isLink'] ?? true;
+$content_series_term_url = get_term_link( $content_series_series );
+
+$content_series_wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class' => 'wp-block-content-series-series-title wp-block-content-series-navigation__series',
+	)
+);
+
+ob_start();
+?>
+<div <?php echo wp_kses_post( $content_series_wrapper_attributes ); ?>>
+	<<?php echo esc_html( $content_series_tag_name ); ?> class="wp-block-content-series-title__heading">
+		<?php if ( $content_series_is_link && ! is_wp_error( $content_series_term_url ) ) : ?>
+			<a href="<?php echo esc_url( $content_series_term_url ); ?>">
+				<?php echo esc_html( $content_series_series->name ); ?>
+			</a>
+		<?php else : ?>
+			<span><?php echo esc_html( $content_series_series->name ); ?></span>
+		<?php endif; ?>
+	</<?php echo esc_html( $content_series_tag_name ); ?>>
+</div>
+<?php
+return ob_get_clean();

--- a/src/blocks/shared/series-context.php
+++ b/src/blocks/shared/series-context.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Shared series context helpers.
+ *
+ * @package ContentSeries
+ */
+
+use Content_Series\Rest_API;
+
+if ( ! function_exists( 'content_series_resolve_post_id' ) ) {
+	/**
+	 * Resolve post ID from block context and common runtime fallbacks.
+	 *
+	 * @param WP_Block $block Block instance.
+	 * @return int|null
+	 */
+	function content_series_resolve_post_id( $block ) {
+		$post_id = 0;
+
+		if ( $block instanceof WP_Block ) {
+			$post_id = absint( $block->context['postId'] ?? 0 );
+		}
+
+		if ( ! $post_id ) {
+			$post_id = absint( get_the_ID() );
+		}
+
+		if ( ! $post_id && isset( $GLOBALS['post'] ) && $GLOBALS['post'] instanceof WP_Post ) {
+			$post_id = absint( $GLOBALS['post']->ID );
+		}
+
+		if ( ! $post_id ) {
+			$post_id = absint( get_queried_object_id() );
+		}
+
+		return $post_id > 0 ? $post_id : null;
+	}
+}
+
+if ( ! function_exists( 'content_series_get_series_context' ) ) {
+	/**
+	 * Get series context data for the current post.
+	 *
+	 * @param WP_Block $block Block instance.
+	 * @return array<string,mixed>|null
+	 */
+	function content_series_get_series_context( $block ) {
+		$post_id = content_series_resolve_post_id( $block );
+
+		if ( ! $post_id ) {
+			return null;
+		}
+
+		static $cache = array();
+		$cache_key    = (string) $post_id;
+
+		if ( array_key_exists( $cache_key, $cache ) ) {
+			return $cache[ $cache_key ];
+		}
+
+		$terms = get_the_terms( $post_id, CONTENT_SERIES_TAXONOMY );
+
+		if ( ! $terms || is_wp_error( $terms ) ) {
+			$cache[ $cache_key ] = null;
+			return null;
+		}
+
+		$series = $terms[0];
+		$posts  = Rest_API::query_series_posts( $series->term_id );
+
+		if ( empty( $posts ) ) {
+			$cache[ $cache_key ] = null;
+			return null;
+		}
+
+		$current_index = -1;
+
+		foreach ( $posts as $index => $post ) {
+			if ( $post->ID === $post_id ) {
+				$current_index = $index;
+				break;
+			}
+		}
+
+		if ( -1 === $current_index ) {
+			$cache[ $cache_key ] = null;
+			return null;
+		}
+
+		$cache[ $cache_key ] = array(
+			'post_id'       => $post_id,
+			'series'        => $series,
+			'posts'         => $posts,
+			'current_index' => $current_index,
+			'prev_post'     => $current_index > 0 ? $posts[ $current_index - 1 ] : null,
+			'next_post'     => $current_index < count( $posts ) - 1 ? $posts[ $current_index + 1 ] : null,
+		);
+
+		return $cache[ $cache_key ];
+	}
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -49,13 +49,23 @@ export interface BlockAttributes {
 	context?: string;
 }
 
-export interface NavigationBlockAttributes {
+export interface NavigationLinkBlockAttributes {
+	direction?: 'previous' | 'next';
 	showTitle?: boolean;
-	showSeriesName?: boolean;
 	showPartNumbers?: boolean;
-	prevLabel?: string;
-	nextLabel?: string;
+	label?: string;
 	arrowStyle?: 'arrow' | 'chevron' | 'none';
+}
+
+export interface SeriesTitleBlockAttributes {
+	isLink?: boolean;
+	level?: number;
+}
+
+export interface SeriesIconBlockAttributes {
+	isLink?: boolean;
+	size?: number;
+	alt?: string;
 }
 
 export interface BlockContext {

--- a/src/types/wordpress-block-editor.d.ts
+++ b/src/types/wordpress-block-editor.d.ts
@@ -8,6 +8,15 @@ declare module '@wordpress/block-editor' {
 
 	export function useBlockProps( props?: BlockProps ): BlockProps;
 
+	export const InnerBlocks: ComponentType< {
+		allowedBlocks?: string[];
+		template?: unknown[];
+		templateLock?: false | 'all' | 'insert';
+		orientation?: 'horizontal' | 'vertical';
+	} > & {
+		Content: ComponentType;
+	};
+
 	export const InspectorControls: ComponentType< {
 		children?: ReactNode;
 		group?: string;

--- a/tests/e2e/series-navigation-frontend.spec.js
+++ b/tests/e2e/series-navigation-frontend.spec.js
@@ -2,7 +2,7 @@ const { test, expect } = require( './playwright' );
 const { loginAsAdmin } = require( './utils/auth' );
 
 test.describe( 'series navigation frontend', () => {
-	test( 'renders previous link for a post in a series', async ( {
+	test( 'renders previous/next links from inner blocks and the series title block', async ( {
 		page,
 	} ) => {
 		await loginAsAdmin( page );
@@ -14,10 +14,11 @@ test.describe( 'series navigation frontend', () => {
 
 		const data = await page.evaluate( async () => {
 			const now = Date.now();
+			const seriesName = `E2E Nav Series ${ now }`;
 			const series = await window.wp.apiFetch( {
 				path: '/wp/v2/series',
 				method: 'POST',
-				data: { name: `E2E Nav Series ${ now }` },
+				data: { name: seriesName },
 			} );
 			const seriesId = series.id;
 
@@ -39,20 +40,30 @@ test.describe( 'series navigation frontend', () => {
 				`E2E Nav Part 1 ${ now }`,
 				1
 			);
-			const second = await createSeriesPost(
-				`E2E Nav Part 2 ${ now }`,
-				2
-			);
+
+			const navigationContent = `
+<!-- wp:content-series/navigation -->
+<!-- wp:content-series/navigation-link {"direction":"previous","showTitle":true,"showPartNumbers":true} /-->
+<!-- wp:content-series/series-title {"isLink":true,"level":3} /-->
+<!-- wp:content-series/navigation-link {"direction":"next","showTitle":true,"showPartNumbers":true} /-->
+<!-- /wp:content-series/navigation -->`.trim();
+
 			const navigationHost = await createSeriesPost(
 				`E2E Nav Host ${ now }`,
-				3,
-				'<!-- wp:content-series/navigation {"showTitle":true,"showPartNumbers":true} /-->'
+				2,
+				navigationContent
+			);
+			const third = await createSeriesPost(
+				`E2E Nav Part 3 ${ now }`,
+				3
 			);
 
 			return {
+				firstTitle: first.title.rendered,
 				firstUrl: first.link,
-				secondTitle: second.title.rendered,
-				secondUrl: second.link,
+				thirdTitle: third.title.rendered,
+				thirdUrl: third.link,
+				seriesName,
 				navigationHostUrl: navigationHost.link,
 			};
 		} );
@@ -61,16 +72,24 @@ test.describe( 'series navigation frontend', () => {
 
 		const block = page
 			.locator( '.wp-block-content-series-navigation' )
-			.filter( { hasText: 'Previous (Part 2)' } )
 			.first();
 		await expect( block ).toBeVisible();
-		await expect( block ).toContainText( 'Previous (Part 2)' );
-		await expect( block ).toContainText( data.secondTitle );
+		await expect( block ).toContainText( 'Previous (Part 1)' );
+		await expect( block ).toContainText( data.firstTitle );
+		await expect( block ).toContainText( 'Next (Part 3)' );
+		await expect( block ).toContainText( data.thirdTitle );
+		await expect(
+			block.locator( '.wp-block-content-series-navigation__series' )
+		).toContainText( data.seriesName );
 
 		const previousHref = await block
 			.locator( '.wp-block-content-series-navigation__prev a' )
 			.getAttribute( 'href' );
+		const nextHref = await block
+			.locator( '.wp-block-content-series-navigation__next a' )
+			.getAttribute( 'href' );
 
-		expect( previousHref ).toBe( data.secondUrl );
+		expect( previousHref ).toBe( data.firstUrl );
+		expect( nextHref ).toBe( data.thirdUrl );
 	} );
 } );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,19 @@ module.exports = {
 		),
 		'blocks/series-navigation/index': path.resolve(
 			__dirname,
-			'src/blocks/series-navigation/index.ts'
+			'src/blocks/series-navigation/index.tsx'
+		),
+		'blocks/series-navigation-link/index': path.resolve(
+			__dirname,
+			'src/blocks/series-navigation-link/index.ts'
+		),
+		'blocks/series-title/index': path.resolve(
+			__dirname,
+			'src/blocks/series-title/index.ts'
+		),
+		'blocks/series-icon/index': path.resolve(
+			__dirname,
+			'src/blocks/series-icon/index.ts'
 		),
 
 		// Block bindings


### PR DESCRIPTION
## Summary
- convert `content-series/navigation` into an `InnerBlocks` wrapper block
- add reusable dynamic child blocks: `content-series/navigation-link`, `content-series/series-title`, and `content-series/series-icon`
- remove legacy self-closing navigation fallback path
- share series/post resolution logic via `src/blocks/shared/series-context.php`
- reuse `series-title` and `series-icon` when rendering the post-list header
- update navigation E2E test to assert serialized wrapper + inner blocks frontend rendering
- fix dynamic block render callbacks to support included render files that return strings

## Validation
- `pnpm lint:js`
- `pnpm check-types`
- `pnpm check-types:tests`
- `pnpm test:js`
- `pnpm build`
- `pnpm wp-scripts test-playwright --config=playwright.config.js --project=chromium tests/e2e/series-navigation-frontend.spec.js`
