### PR TITLE
Add GitHub Actions workflow to build release zip

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -11,8 +11,7 @@ vendor/
 
 # Config files
 webpack.config.js
-tsconfig.json
-tsconfig.test.json
+tsconfig*.json
 phpunit.xml
 phpunit.xml.dist
 composer.json
@@ -24,6 +23,9 @@ jest.config.js
 .wp-env.json
 .eslintrc.js
 phpcs.xml.dist
+
+CLAUDE.md
+*.log
 
 # CI / IDE / VCS
 .git/

--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,41 @@
+# Development sources
+src/
+tests/
+bin/
+docs/
+
+# Node / Composer
+node_modules/
+vendor/
+.pnpm-store/
+
+# Config files
+webpack.config.js
+tsconfig.json
+tsconfig.test.json
+phpunit.xml
+phpunit.xml.dist
+composer.json
+composer.lock
+package.json
+pnpm-lock.yaml
+playwright.config.js
+jest.config.js
+.wp-env.json
+.eslintrc.js
+phpcs.xml.dist
+
+# CI / IDE / VCS
+.git/
+.github/
+.claude/
+.cursor/
+.gitignore
+.phpunit.result.cache
+
+# Artifacts
+coverage/
+playwright-report/
+test-results/
+artifacts/
+ignore/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+    release:
+        types: [published]
+    workflow_dispatch:
+
+permissions:
+    contents: write
+
+jobs:
+    build-zip:
+        name: Build Plugin Zip
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: pnpm
+
+            - name: Install Node dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build plugin assets
+              run: pnpm build
+
+            - name: Get version from tag
+              id: version
+              run: |
+                  if [ "${{ github.event_name }}" = "release" ]; then
+                    VERSION="${{ github.event.release.tag_name }}"
+                    VERSION="${VERSION#v}"
+                  else
+                    VERSION="dev-$(git rev-parse --short HEAD)"
+                  fi
+                  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+            - name: Assemble plugin directory
+              run: |
+                  PLUGIN_SLUG="content-series"
+                  DIST_DIR="dist/${PLUGIN_SLUG}"
+                  mkdir -p "$DIST_DIR"
+
+                  # Sync files, excluding patterns from .distignore
+                  rsync -av --exclude-from='.distignore' ./ "$DIST_DIR/"
+
+                  # Remove .distignore from the output (it excludes others but not itself)
+                  rm -f "$DIST_DIR/.distignore"
+
+            - name: Create zip
+              run: |
+                  PLUGIN_SLUG="content-series"
+                  VERSION="${{ steps.version.outputs.version }}"
+                  cd dist
+                  zip -r "../${PLUGIN_SLUG}-${VERSION}.zip" "${PLUGIN_SLUG}/"
+
+            - name: Upload zip as workflow artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: content-series-${{ steps.version.outputs.version }}
+                  path: content-series-${{ steps.version.outputs.version }}.zip
+
+            - name: Attach zip to GitHub Release
+              if: github.event_name == 'release'
+              uses: softprops/action-gh-release@v2
+              with:
+                  files: content-series-${{ steps.version.outputs.version }}.zip

--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 A modern, block-editor-native WordPress plugin for managing content series. Group posts together into series with full Gutenberg integration.
 
-> [!Note]
-> This is mostly for personal use right now as I'm using this partially as an experiment to see how far I can get with just vibe-coding (for the most part - still need to review/fix!).
-
 ## Features
 
 - **Block Editor Native**: Built specifically for the WordPress block editor (Gutenberg)
-- **Series Taxonomy**: Organize posts into series using a custom taxonomy
-- **Custom Blocks**: Two powerful blocks for displaying series content:
-  - **Series Navigation**: Display previous/next navigation within a series
-  - **Series Post List**: Show a list of all posts in the current series
-- **Editor Integration**: Sidebar fields for series order and optional short titles
+- **Series Taxonomy**: Organize posts into series using a custom `series` taxonomy
+- **Five Custom Blocks**:
+  - **Series Post List** — ordered list of all posts in the current series, with configurable headers
+  - **Series Navigation** — wrapper block for previous/next links and series metadata
+  - **Series Navigation Link** — previous or next post link with arrows, part numbers, and titles
+  - **Series Title** — displays the current series name as a heading, optionally linked to the archive
+  - **Series Icon** — displays the series icon image, optionally linked to the archive
+- **Editor Sidebar**: Assign posts to a series, set part/order numbers, and add optional short titles
 - **Quick Edit Support**: Edit series part numbers directly from the posts list table
-- **Catalog Variation**: A `core/terms-query` variation for displaying all series
-- **Block Bindings**: Custom term-meta binding source for series metadata (e.g. icon)
-- **Archive Enhancements**: Adds contextual series information on non-series archive views
-- **Legacy Compatibility**: Compatible with the PublishPress Series plugin (uses the same taxonomy slug)
-- **REST API Support**: Full REST API integration for headless WordPress setups
-- **Block Templates**: Archive and catalog block templates for series display
+- **Series Catalog**: A dedicated `/series/` page listing all series in a grid with icons, descriptions, and post counts (powered by a `core/terms-query` block variation)
+- **Series Archive Templates**: Block-based templates for individual series archives and the series catalog page
+- **Block Bindings**: A `content-series/term-meta` binding source for connecting blocks to series metadata (e.g. binding an image block to the series icon)
+- **Archive Enhancements**: Automatically appends series information ("Series: Name — Part N") to post excerpts on home, archive, and search pages
+- **REST API**: Custom endpoints for listing series posts in order and bulk-reordering
+- **PublishPress Series Migration**: Automatic data migration from the legacy PublishPress Series plugin on activation (shared taxonomy slug, icon import)
 
 ## Requirements
 
@@ -29,32 +29,31 @@ A modern, block-editor-native WordPress plugin for managing content series. Grou
 
 ## Installation
 
-1. Download or clone this repository into your WordPress plugins directory:
+### From a Release (recommended)
+
+1. Download the latest `content-series-{version}.zip` from the [Releases](https://github.com/nerrad/content-series/releases) page
+2. In WordPress, go to **Plugins > Add New > Upload Plugin**
+3. Upload the zip file and click **Install Now**
+4. Activate the plugin
+
+### From Source
+
+1. Clone the repository into your plugins directory:
 
    ```bash
    cd wp-content/plugins
    git clone https://github.com/nerrad/content-series.git
    ```
 
-2. Install PHP dependencies:
+2. Install dependencies and build:
 
    ```bash
-   composer install
-   ```
-
-3. Install Node.js dependencies:
-
-   ```bash
+   cd content-series
    pnpm install
-   ```
-
-4. Build the plugin assets:
-
-   ```bash
    pnpm build
    ```
 
-5. Activate the plugin through the WordPress admin panel.
+3. Activate the plugin through the WordPress admin panel.
 
 ## Development
 
@@ -176,71 +175,108 @@ The wrapper script automatically sets up the shared environment and points it to
 ### Creating a Series
 
 1. Go to **Posts > Series** in the WordPress admin
-2. Create a new series term
-3. Optionally set series metadata (icon, description, etc.)
+2. Create a new series with a name, slug, and description
+3. Optionally upload a series icon image
 
 ### Adding Posts to a Series
 
 1. Edit a post in the block editor
-2. Use the Series panel in the sidebar to assign the post to a series
-3. Set the post's part number and optional short title
+2. Open the **Series** panel in the post settings sidebar
+3. Assign the post to a series
+4. Set the post's **part number** (order within the series)
+5. Optionally set a **short title** for use in series listings
 
-### Using the Blocks
+Part numbers can also be edited via **Quick Edit** on the Posts list table.
 
-#### Series Navigation Block
+### Blocks
 
-Add the Series Navigation block to display previous/next links within a series. Options include:
+All blocks are designed for use in post templates or individual posts.
 
-- Show/hide series name
+#### Series Post List
+
+Displays an ordered list of all posts in the current series, with links. Useful for showing readers the full series at a glance.
+
 - Show/hide part numbers
-- Customize previous/next labels
-- Choose arrow style (arrow, chevron, or none)
+- Use full titles or short titles
+- Highlight the current post
+- Supports a customizable header area (via inner blocks) for the series title and icon
 
-#### Series Post List Block
+#### Series Navigation
 
-Add the Series Post List block to display all posts in the current series. Options include:
+A wrapper block that provides previous/next navigation within a series. Add child blocks inside it:
 
-- Use ordered or unordered list display
-- Show/hide short titles
-- Highlight current post
-- Show/hide series title and icon
+- **Series Navigation Link** — a previous or next link. Options:
+  - Direction: previous or next
+  - Show/hide post title
+  - Show/hide part numbers
+  - Arrow style: arrow, chevron, or none
+  - Custom label text
+- **Series Title** — displays the series name as a heading (h1–h6), optionally linked to the series archive
+- **Series Icon** — displays the series icon image, optionally linked to the series archive
+
+#### Series Catalog
+
+The plugin registers a `/series/` page that displays all series in a grid layout. Each series shows its icon, name, post count, and description. This uses a `core/terms-query` block variation (`content-series/catalog`) and a block template.
+
+### Series Archives
+
+Each series automatically gets an archive page at `/series/{slug}/` showing the series title, description, and a post list. These archives use block templates registered by the plugin.
+
+On non-series archive pages (home, category, tag, search), posts that belong to a series automatically display a "Series: Name — Part N" link below their excerpt.
+
+### REST API
+
+The plugin provides custom REST API endpoints under the `content-series/v1` namespace:
+
+- **`GET /content-series/v1/series/{id}/posts`** — returns all posts in a series, ordered by part number
+- **`POST /content-series/v1/series/{id}/reorder`** — bulk-update post order within a series (requires `edit_posts` capability)
+- **`GET /content-series/v1/series`** — returns all series with metadata including icon URLs
+
+The standard WordPress REST API endpoint at `/wp/v2/series` is also available with enhanced responses that include icon data.
+
+### Migrating from PublishPress Series
+
+If you previously used the PublishPress Series plugin, Content Series automatically migrates your data on activation:
+
+- Series terms and post assignments are preserved (both plugins use the `series` taxonomy slug)
+- Series icons are imported from the legacy `orgseriesicons` table into standard term meta
+- A one-time admin notice confirms migration results
 
 ## Project Structure
 
 ```
 content-series/
-├── .github/workflows/  # CI workflows
-├── assets/             # Admin quick-edit assets
+├── .github/workflows/  # CI and release workflows
+├── assets/             # Admin quick-edit CSS/JS
 ├── bin/scripts/        # Local environment helper scripts
 ├── build/              # Generated JS/CSS build artifacts
 ├── includes/           # PHP classes
-│   ├── class-admin.php
-│   ├── class-block-bindings.php
-│   ├── class-block-variations.php
-│   ├── class-content-series.php
-│   ├── class-migration.php
-│   ├── class-post-meta.php
-│   ├── class-rest-api.php
-│   ├── class-taxonomy.php
-│   ├── class-templates.php
-│   └── class-term-meta.php
-├── src/                # Source files
+│   ├── class-admin.php             # Quick edit support
+│   ├── class-block-bindings.php    # Term meta binding source
+│   ├── class-block-variations.php  # Series catalog variation
+│   ├── class-content-series.php    # Main plugin orchestrator
+│   ├── class-migration.php         # PublishPress Series migration
+│   ├── class-post-meta.php         # Post meta (part number, short title)
+│   ├── class-rest-api.php          # Custom REST endpoints
+│   ├── class-taxonomy.php          # Series taxonomy registration
+│   ├── class-templates.php         # Block templates and archive display
+│   └── class-term-meta.php         # Term meta (series icons)
+├── src/                # TypeScript/TSX source files
 │   ├── blocks/         # Block definitions
+│   │   ├── series-icon/
 │   │   ├── series-navigation/
-│   │   └── series-post-list/
-│   ├── bindings/       # Block bindings source registration
-│   ├── sidebar/        # Editor sidebar components
-│   ├── variations/     # Block variations
-│   └── types/          # TypeScript type definitions
-├── tests/              # Test files (PHP, JS setup, E2E)
-├── jest.config.js      # Jest configuration
-├── playwright.config.js # Playwright configuration
+│   │   ├── series-navigation-link/
+│   │   ├── series-post-list/
+│   │   └── series-title/
+│   ├── bindings/       # Block bindings (client-side)
+│   ├── sidebar/        # Editor sidebar panel
+│   ├── types/          # TypeScript type definitions
+│   └── variations/     # Block variations (client-side)
+├── tests/              # PHPUnit, Jest, and Playwright tests
 ├── content-series.php  # Main plugin file
-├── composer.json       # PHP dependencies
-├── package.json        # Node.js dependencies
-├── tsconfig.json       # TypeScript config for source
-├── tsconfig.tests.json # TypeScript config for tests
-└── README.md           # This file
+├── uninstall.php       # Cleanup on plugin deletion
+├── .distignore         # Files excluded from release zips
+└── README.md
 ```
 
 ## Testing
@@ -308,6 +344,43 @@ environment variables.
 - **CSS**: Follows WordPress CSS coding standards
 
 Linting is enforced via PHPCS and wp-scripts. Run `pnpm lint:php:fix` to auto-fix PHP issues.
+
+## Releases
+
+Release zips are built automatically by GitHub Actions when a new release is published.
+
+### Creating a Release
+
+1. Go to **[Releases](https://github.com/nerrad/content-series/releases)** on GitHub
+2. Click **Draft a new release**
+3. Create a new tag (e.g. `v1.0.0`) targeting the `trunk` branch
+4. Add a release title and description
+5. Click **Publish release**
+
+The workflow will automatically:
+- Check out the tagged commit
+- Install dependencies and build assets (`pnpm build`)
+- Assemble a `content-series-{version}.zip` containing only distribution files
+- Attach the zip to the release as a downloadable asset
+
+### Testing a Build
+
+To test the zip build without creating a release, trigger the workflow manually:
+
+1. Go to **Actions > Release** on GitHub
+2. Click **Run workflow**
+3. Download the zip from the workflow run's artifacts
+
+### What's in the Zip
+
+The release zip contains a `content-series/` directory with:
+- `content-series.php` and `uninstall.php`
+- `includes/` (PHP classes)
+- `build/` (compiled block JS/CSS)
+- `assets/` (admin CSS/JS)
+- `README.md`
+
+Development files (source, tests, configs, node_modules) are excluded via `.distignore`.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Closes #33

- Adds `.distignore` defining files to exclude from the distribution zip (dev sources, configs, CI/IDE files, artifacts)
- Adds `.github/workflows/release.yml` that builds a distributable plugin zip on release publish (or manual dispatch)

### How the workflow works

1. Triggers on GitHub Release creation (`published`) or manual `workflow_dispatch`
2. Checks out tagged commit, installs Node deps, runs `pnpm build`
3. Assembles zip using `rsync --exclude-from=.distignore` — only distribution files are included
4. Creates `content-series-{version}.zip` with standard WP plugin directory structure
5. Uploads zip as workflow artifact (always) and attaches to GitHub Release (on publish)

### What's in the zip

- `content-series.php`, `uninstall.php`
- `includes/` (PHP classes)
- `build/` (compiled JS/CSS/block.json)
- `assets/` (non-compiled quick-edit CSS/JS)
- `README.md`

### What's excluded

Dev sources (`src/`, `tests/`), node_modules, config files (webpack, tsconfig, phpunit, composer, eslint, etc.), CI/IDE directories, artifacts.

### Notes

- No Composer install step — `composer.json` has zero production dependencies
- Uses `softprops/action-gh-release@v2` for release asset upload
- Version extracted from tag (strips `v` prefix); falls back to `dev-<sha>` on manual dispatch
- Locally verified: zip contents are clean, all essential files present, no dev artifacts leaked

## Test plan

- [ ] Trigger workflow via manual dispatch (Actions tab → Release → Run workflow)
- [ ] Verify the workflow artifact zip contains the correct files
- [ ] Create a test release and verify zip is attached as a release asset
- [ ] Download zip and install via Plugins → Add New → Upload Plugin in WordPress