### PR TITLE
Fix clickable links in editor navigating away from template

### DIFF
--- a/src/blocks/series-icon/edit.tsx
+++ b/src/blocks/series-icon/edit.tsx
@@ -67,7 +67,7 @@ export default function Edit( {
 
 			<div { ...blockProps }>
 				{ isLink ?? true ? (
-					<a href="https://example.com">
+					<a>
 						<span
 							className="wp-block-content-series-series-icon__image wp-block-content-series-navigation__icon wp-block-content-series-navigation__icon--placeholder"
 							style={ {

--- a/src/blocks/series-navigation-link/edit.tsx
+++ b/src/blocks/series-navigation-link/edit.tsx
@@ -145,7 +145,7 @@ export default function Edit( {
 			</InspectorControls>
 
 			<div { ...blockProps }>
-				<a href="https://example.com">
+				<a>
 					{ isPrevious && arrows.prev && (
 						<span className="wp-block-content-series-navigation__arrow">
 							{ arrows.prev }

--- a/src/blocks/series-title/edit.tsx
+++ b/src/blocks/series-title/edit.tsx
@@ -62,7 +62,7 @@ export default function Edit( {
 			<div { ...blockProps }>
 				<HeadingTag className="wp-block-content-series-title__heading">
 					{ isLink ?? true ? (
-						<a href="https://example.com">
+						<a>
 							{ __( 'Series title', 'content-series' ) }
 						</a>
 					) : (


### PR DESCRIPTION
## Summary

- Remove placeholder `href="https://example.com"` from `<a>` tags in the editor components for series-title, series-icon, and series-navigation-link blocks
- Clicking these links in the editor was navigating away from the template and triggering a cross-origin `SecurityError`
- An `<a>` without `href` is valid HTML, preserves CSS styling parity with frontend output, and is non-navigable

## Test plan

- [ ] Edit a single post template containing a Series Post List block — click the series title and icon in the header; should select the block, not navigate away
- [ ] Edit a template with a Series Navigation block — click the navigation links, title, icon; should select the block, not navigate away
- [ ] On the frontend, verify series links still work correctly (server-side rendering is unaffected)