### PR TITLE
[codex] Fix legacy series icon migration

### DIFF
--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -143,7 +143,12 @@ class Migration {
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- One-time migration table lookup.
-		$tables = $wpdb->get_col( 'SHOW TABLES' );
+		$tables = $wpdb->get_col(
+			$wpdb->prepare(
+				'SHOW TABLES LIKE %s',
+				$wpdb->esc_like( $wpdb->prefix ) . '%'
+			)
+		);
 		foreach ( $tables as $existing_table_name ) {
 			if ( 0 === strcasecmp( $existing_table_name, $expected_table_name ) ) {
 				return $existing_table_name;
@@ -167,6 +172,11 @@ class Migration {
 
 		if ( preg_match( '#^https?://#i', $icon_url ) ) {
 			return $icon_url;
+		}
+
+		if ( false === strpos( $icon_url, '/' ) ) {
+			$upload_dir = wp_upload_dir();
+			return trailingslashit( $upload_dir['baseurl'] ) . 'series_icons/' . $icon_url;
 		}
 
 		return home_url( '/' . ltrim( $icon_url, '/' ) );

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -81,25 +81,15 @@ class Migration {
 	private function migrate_icons() {
 		global $wpdb;
 
-		$table_name = $wpdb->prefix . self::LEGACY_ICONS_TABLE;
+		$table_name = $this->get_legacy_icons_table_name();
 
-		// Check if legacy table exists.
-		$table_exists = $wpdb->get_var(
-			$wpdb->prepare(
-				'SHOW TABLES LIKE %s',
-				$table_name
-			)
-		);
-
-		if ( ! $table_exists ) {
+		if ( ! $table_name ) {
 			return;
 		}
 
-		// Get all icons from legacy table.
-		// Table name is constructed from safe values (wpdb prefix + constant).
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- One-time migration from a legacy custom table.
 		$icons = $wpdb->get_results(
-			"SELECT term_id, icon FROM {$wpdb->_escape( $table_name )}"
+			$wpdb->prepare( 'SELECT term_id, icon FROM %i', $table_name )
 		);
 
 		if ( ! $icons ) {
@@ -121,16 +111,65 @@ class Migration {
 				continue;
 			}
 
-			// Check if icon URL is a full URL or just a filename.
-			if ( strpos( $icon_url, 'http' ) !== 0 ) {
-				// It's likely a relative path or filename, try to construct full URL.
-				$upload_dir = wp_upload_dir();
-				$icon_url   = trailingslashit( $upload_dir['baseurl'] ) . 'series_icons/' . $icon_url;
-			}
+			$icon_url = $this->normalize_legacy_icon_url( $icon_url );
 
 			// Save to term meta.
 			update_term_meta( $term_id, Term_Meta::ICON_META_KEY, esc_url_raw( $icon_url ) );
 		}
+	}
+
+	/**
+	 * Get the legacy icons table name.
+	 *
+	 * Older Organize Series installs used a mixed-case orgSeriesIcons table name.
+	 * Resolve the actual table case from the database so those installs migrate too.
+	 *
+	 * @return string|false Legacy icons table name, or false if it does not exist.
+	 */
+	private function get_legacy_icons_table_name() {
+		global $wpdb;
+
+		$expected_table_name = $wpdb->prefix . self::LEGACY_ICONS_TABLE;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- One-time migration table lookup.
+		$table_name = $wpdb->get_var(
+			$wpdb->prepare(
+				'SHOW TABLES LIKE %s',
+				$wpdb->esc_like( $expected_table_name )
+			)
+		);
+
+		if ( $table_name ) {
+			return $table_name;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- One-time migration table lookup.
+		$tables = $wpdb->get_col( 'SHOW TABLES' );
+		foreach ( $tables as $existing_table_name ) {
+			if ( 0 === strcasecmp( $existing_table_name, $expected_table_name ) ) {
+				return $existing_table_name;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Convert a legacy icon value to an absolute URL.
+	 *
+	 * PublishPress Series stores uploaded media as a path relative to the WordPress
+	 * root, then renders it by appending that value to home_url( '/' ).
+	 *
+	 * @param string $icon_url Legacy icon value.
+	 * @return string Absolute icon URL.
+	 */
+	private function normalize_legacy_icon_url( $icon_url ) {
+		$icon_url = trim( (string) $icon_url );
+
+		if ( preg_match( '#^https?://#i', $icon_url ) ) {
+			return $icon_url;
+		}
+
+		return home_url( '/' . ltrim( $icon_url, '/' ) );
 	}
 
 	/**
@@ -141,6 +180,7 @@ class Migration {
 	private function get_migrated_icons_count() {
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Count term meta after a one-time migration.
 		return (int) $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(*) FROM {$wpdb->termmeta} WHERE meta_key = %s AND meta_value != ''",

--- a/tests/MigrationTest.php
+++ b/tests/MigrationTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Tests for Migration class.
+ *
+ * @package ContentSeries
+ */
+
+namespace Content_Series\Tests;
+
+// phpcs:disable WordPress.Files.FileName -- Match the repository's existing *Test.php naming convention.
+// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Tests intentionally create a legacy custom table.
+
+use Content_Series\Migration;
+use Content_Series\Term_Meta;
+use WP_UnitTestCase;
+
+/**
+ * Test suite for Migration class.
+ */
+class MigrationTest extends WP_UnitTestCase {
+
+	/**
+	 * Legacy icons table name for the current test.
+	 *
+	 * @var string
+	 */
+	private $legacy_icons_table;
+
+	/**
+	 * Set up test data.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		global $wpdb;
+
+		$this->legacy_icons_table = $wpdb->prefix . 'orgSeriesIcons';
+
+		delete_option( Migration::MIGRATION_OPTION );
+		delete_option( Migration::LEGACY_OPTIONS_KEY );
+		$wpdb->query( "DROP TABLE IF EXISTS `{$this->legacy_icons_table}`" );
+	}
+
+	/**
+	 * Clean up test data.
+	 */
+	public function tear_down() {
+		global $wpdb;
+
+		$wpdb->query( "DROP TABLE IF EXISTS `{$this->legacy_icons_table}`" );
+		delete_option( Migration::MIGRATION_OPTION );
+		delete_option( Migration::LEGACY_OPTIONS_KEY );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that mixed-case legacy tables and root-relative icon paths migrate.
+	 */
+	public function test_migrates_mixed_case_legacy_icon_table_with_root_relative_icon_path() {
+		global $wpdb;
+
+		$term_id = $this->factory->term->create(
+			array(
+				'taxonomy' => 'series',
+				'name'     => 'Icon Series',
+			)
+		);
+		$icon    = 'wp-content/uploads/2011/01/UKRAINEMISSIONSLOGO-300x300.jpg';
+
+		update_option( Migration::LEGACY_OPTIONS_KEY, array( 'active' => true ) );
+
+		$wpdb->query(
+			"CREATE TABLE `{$this->legacy_icons_table}` (
+				term_id INT NOT NULL,
+				icon VARCHAR(255) NOT NULL,
+				PRIMARY KEY (term_id)
+			)"
+		);
+		$wpdb->insert(
+			$this->legacy_icons_table,
+			array(
+				'term_id' => $term_id,
+				'icon'    => $icon,
+			),
+			array( '%d', '%s' )
+		);
+
+		$migration = new Migration();
+		$this->assertTrue( $migration->maybe_migrate() );
+
+		$this->assertSame(
+			home_url( '/' . $icon ),
+			get_term_meta( $term_id, Term_Meta::ICON_META_KEY, true )
+		);
+	}
+}

--- a/tests/MigrationTest.php
+++ b/tests/MigrationTest.php
@@ -55,20 +55,29 @@ class MigrationTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that mixed-case legacy tables and root-relative icon paths migrate.
+	 * Create a series term.
+	 *
+	 * @param string $name Series term name.
+	 * @return int Created term ID.
 	 */
-	public function test_migrates_mixed_case_legacy_icon_table_with_root_relative_icon_path() {
-		global $wpdb;
-
+	private function create_series_term( $name ) {
 		$term_id = $this->factory->term->create(
 			array(
 				'taxonomy' => 'series',
-				'name'     => 'Icon Series',
+				'name'     => $name,
 			)
 		);
-		$icon    = 'wp-content/uploads/2011/01/UKRAINEMISSIONSLOGO-300x300.jpg';
 
-		update_option( Migration::LEGACY_OPTIONS_KEY, array( 'active' => true ) );
+		$this->assertIsInt( $term_id );
+
+		return $term_id;
+	}
+
+	/**
+	 * Create the legacy icons table.
+	 */
+	private function create_legacy_icons_table() {
+		global $wpdb;
 
 		$wpdb->query(
 			"CREATE TABLE `{$this->legacy_icons_table}` (
@@ -77,6 +86,17 @@ class MigrationTest extends WP_UnitTestCase {
 				PRIMARY KEY (term_id)
 			)"
 		);
+	}
+
+	/**
+	 * Insert a legacy icon row.
+	 *
+	 * @param int    $term_id Series term ID.
+	 * @param string $icon Legacy icon value.
+	 */
+	private function insert_legacy_icon( $term_id, $icon ) {
+		global $wpdb;
+
 		$wpdb->insert(
 			$this->legacy_icons_table,
 			array(
@@ -85,12 +105,121 @@ class MigrationTest extends WP_UnitTestCase {
 			),
 			array( '%d', '%s' )
 		);
+	}
+
+	/**
+	 * Prime migration by adding the legacy option.
+	 */
+	private function add_legacy_options() {
+		update_option( Migration::LEGACY_OPTIONS_KEY, array( 'active' => true ) );
+	}
+
+	/**
+	 * Test that mixed-case legacy tables and root-relative icon paths migrate.
+	 */
+	public function test_migrates_mixed_case_legacy_icon_table_with_root_relative_icon_path() {
+		$term_id = $this->create_series_term( 'Icon Series' );
+		$icon    = 'wp-content/uploads/2011/01/UKRAINEMISSIONSLOGO-300x300.jpg';
+
+		$this->add_legacy_options();
+		$this->create_legacy_icons_table();
+		$this->insert_legacy_icon( $term_id, $icon );
 
 		$migration = new Migration();
 		$this->assertTrue( $migration->maybe_migrate() );
 
 		$this->assertSame(
 			home_url( '/' . $icon ),
+			get_term_meta( $term_id, Term_Meta::ICON_META_KEY, true )
+		);
+	}
+
+	/**
+	 * Test that absolute icon URLs pass through unchanged.
+	 */
+	public function test_migrates_absolute_icon_url_without_rewriting() {
+		$term_id = $this->create_series_term( 'Absolute Icon Series' );
+		$icon    = 'https://example.com/wp-content/uploads/icon.png';
+
+		$this->add_legacy_options();
+		$this->create_legacy_icons_table();
+		$this->insert_legacy_icon( $term_id, $icon );
+
+		$migration = new Migration();
+		$this->assertTrue( $migration->maybe_migrate() );
+
+		$this->assertSame(
+			$icon,
+			get_term_meta( $term_id, Term_Meta::ICON_META_KEY, true )
+		);
+	}
+
+	/**
+	 * Test that bare filenames preserve the legacy series_icons location.
+	 */
+	public function test_migrates_bare_icon_filename_to_legacy_series_icons_url() {
+		$term_id = $this->create_series_term( 'Bare Filename Series' );
+		$icon    = 'my-icon.png';
+
+		$this->add_legacy_options();
+		$this->create_legacy_icons_table();
+		$this->insert_legacy_icon( $term_id, $icon );
+
+		$migration = new Migration();
+		$this->assertTrue( $migration->maybe_migrate() );
+
+		$upload_dir = wp_upload_dir();
+
+		$this->assertSame(
+			trailingslashit( $upload_dir['baseurl'] ) . 'series_icons/' . $icon,
+			get_term_meta( $term_id, Term_Meta::ICON_META_KEY, true )
+		);
+	}
+
+	/**
+	 * Test that missing legacy icon tables still complete migration.
+	 */
+	public function test_migration_completes_when_legacy_icons_table_is_missing() {
+		$term_id = $this->create_series_term( 'No Table Series' );
+
+		$this->add_legacy_options();
+
+		$migration = new Migration();
+		$this->assertTrue( $migration->maybe_migrate() );
+		$this->assertSame( '', get_term_meta( $term_id, Term_Meta::ICON_META_KEY, true ) );
+	}
+
+	/**
+	 * Test that migration does not run after it has already completed.
+	 */
+	public function test_migration_does_not_overwrite_icons_after_already_migrated() {
+		global $wpdb;
+
+		$term_id    = $this->create_series_term( 'Already Migrated Series' );
+		$first_icon = 'wp-content/uploads/2011/01/first-icon.png';
+
+		$this->add_legacy_options();
+		$this->create_legacy_icons_table();
+		$this->insert_legacy_icon( $term_id, $first_icon );
+
+		$migration = new Migration();
+		$this->assertTrue( $migration->maybe_migrate() );
+
+		$wpdb->update(
+			$this->legacy_icons_table,
+			array(
+				'icon' => 'wp-content/uploads/2011/01/second-icon.png',
+			),
+			array(
+				'term_id' => $term_id,
+			),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		$this->assertFalse( $migration->maybe_migrate() );
+		$this->assertSame(
+			home_url( '/' . $first_icon ),
 			get_term_meta( $term_id, Term_Meta::ICON_META_KEY, true )
 		);
 	}


### PR DESCRIPTION
## Summary

- Resolve the PublishPress/Organize Series icon table by matching the actual database table name case-insensitively, so older `orgSeriesIcons` installs can migrate.
- Normalize legacy icon values using the PublishPress Series rendering contract: root-relative paths are rebuilt from `home_url( '/' )` instead of being treated as filenames under `uploads/series_icons/`.
- Add a migration test covering a mixed-case legacy table with a `wp-content/uploads/...` icon path.

## Validation

- `vendor/bin/phpcs -s includes/class-migration.php tests/MigrationTest.php`
- Isolated wp-env on ports 8898/8899: `vendor/bin/phpunit` passed with 8 tests and 18 assertions.